### PR TITLE
Add payment handling for package builder

### DIFF
--- a/perch/addons/apps/perch_shop/runtime/packages.php
+++ b/perch/addons/apps/perch_shop/runtime/packages.php
@@ -53,10 +53,10 @@ function perch_shop_update_package_status($status)
 
     $API      = new PerchAPI(1.0, 'perch_shop');
     $Packages = new PerchShop_Packages($API);
-    $Package  = $Packages->find((int)$_SESSION['perch_shop_package_id']);
+    $Package  = $Packages->find_by_uuid($_SESSION['perch_shop_package_id']);
 
     if ($Package) {
-        return $Package->update(['status' => $status]);
+        $Package->update(['status' => $status]);
     }
 
     return $Package;

--- a/perch/templates/pages/order/package-builder.php
+++ b/perch/templates/pages/order/package-builder.php
@@ -40,6 +40,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     if ($package) {
 
                     $_SESSION['perch_shop_package_id']= $_SESSION['draft_package']['id'];
+                    $_SESSION['package_billing_type'] = $_SESSION['draft_package']['billing'];
                     print_r($_SESSION['draft_package']['selections']);
                     perch_shop_add_package_item($package->id(), $_SESSION['draft_package']['selections']);
                           unset($_SESSION['draft_package']);

--- a/perch/templates/pages/order/package-summary.php
+++ b/perch/templates/pages/order/package-summary.php
@@ -1,7 +1,6 @@
 <?php  if (session_status() === PHP_SESSION_NONE) {
               session_start();
           } //include('../perch/runtime.php');
-print_r($_SESSION);
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $quantities = perch_post('qty');
     $removals = perch_post('remove');
@@ -21,8 +20,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         try {
             $package = perch_shop_update_package_status("confirmed");
             if ($package) {
-            echo "checkout";print_r($package);
-              //  $result= perch_shop_add_to_cart($_POST["dose"]);
+                $billing = $_SESSION['package_billing_type'] ?? 'prepaid';
+                $items   = $package->get_items();
+                if (is_array($items)) {
+                    foreach ($items as $Item) {
+                        if ($billing === 'monthly' && (int)$Item->month() > 1) {
+                            continue;
+                        }
+                        $productID = $Item->variantID() ? $Item->variantID() : $Item->productID();
+                        if ($productID) {
+                            perch_shop_add_to_cart($productID, $Item->qty());
+                        }
+                    }
+                }
                 PerchUtil::redirect('checkout.php');
             }
         } catch (Exception $e) {


### PR DESCRIPTION
## Summary
- Persist package billing choice in the session when creating a package
- Resolve package lookups by UUID and update status accordingly
- Populate the cart based on billing type so prepaid orders pay in full while monthly orders only add the first month

## Testing
- `php -l perch/addons/apps/perch_shop/runtime/packages.php`
- `php -l perch/templates/pages/order/package-builder.php`
- `php -l perch/templates/pages/order/package-summary.php`


------
https://chatgpt.com/codex/tasks/task_b_68b97aca839c8324bd7efb49d5fb77e4