### PR TITLE
Show future package payments on client orders

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Packages.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Packages.class.php
@@ -5,8 +5,8 @@ class PerchShop_Packages extends PerchShop_Factory
     public $api_method         = 'packages';
     public $api_list_method    = 'packages';
     public $singular_classname = 'PerchShop_Package';
-    public $static_fields      = ['customerID', 'month', 'status'];
-    public $remote_fields      = ['customerID', 'month', 'status'];
+    public $static_fields      = ['customerID', 'month', 'status', 'packageDate', 'packageStatus', 'uuid'];
+    public $remote_fields      = ['customerID', 'month', 'status', 'packageDate', 'packageStatus', 'uuid'];
 
     protected $table               = 'shop_packages';
     protected $pk                  = 'packageID';

--- a/perch/addons/apps/perch_shop/runtime/packages.php
+++ b/perch/addons/apps/perch_shop/runtime/packages.php
@@ -4,8 +4,6 @@ function perch_shop_create_package($data)
 {
     $API      = new PerchAPI(1.0, 'perch_shop');
     $Packages = new PerchShop_Packages($API);
-    echo "new package";
-    print_r($data);
     return $Packages->create($data);
 }
 
@@ -14,7 +12,6 @@ function perch_shop_add_package_item($packageID, $data)
     $API   = new PerchAPI(1.0, 'perch_shop');
     $Items = new PerchShop_PackageItems($API);
 
-    echo "perch_shop_add_package_item";
     $data['packageID'] = $packageID;
 
     return  $Items->create($data);
@@ -53,10 +50,10 @@ function perch_shop_update_package_status($status)
 
     $API      = new PerchAPI(1.0, 'perch_shop');
     $Packages = new PerchShop_Packages($API);
-    $Package  = $Packages->find((int)$_SESSION['perch_shop_package_id']);
+    $Package  = $Packages->find_by_uuid($_SESSION['perch_shop_package_id']);
 
     if ($Package) {
-        return $Package->update(['status' => $status]);
+        $Package->update(['status' => $status]);
     }
 
     return $Package;
@@ -121,6 +118,66 @@ function perch_shop_package_contents($opts = [], $return = false)
 
     $Template = new PerchTemplate('shop/' . $opts['template']);
     $r        = $Template->render(['packageitems' => $data]);
+
+    if ($return) {
+        return $r;
+    }
+
+    echo $r;
+    PerchUtil::flush_output();
+    return true;
+}
+
+function perch_shop_future_packages($opts = [], $return = false)
+{
+    $opts = PerchUtil::extend([
+        'template'      => 'packages/future.html',
+        'skip-template' => false,
+    ], $opts);
+
+    if ($opts['skip-template']) {
+        $return = true;
+    }
+
+    if (!perch_member_logged_in()) {
+        if ($return) {
+            return $opts['skip-template'] ? [] : '';
+        }
+        echo '';
+        PerchUtil::flush_output();
+        return true;
+    }
+
+    $Runtime    = PerchShop_Runtime::fetch();
+    $customerID = $Runtime->get_customer_id();
+
+    $API      = new PerchAPI(1.0, 'perch_shop');
+    $Packages = new PerchShop_Packages($API);
+    $packages = $Packages->get_for_customer($customerID);
+
+    $data  = [];
+    $today = time();
+
+    if (PerchUtil::count($packages)) {
+        foreach ($packages as $Package) {
+            $date   = $Package->packageDate();
+            $status = $Package->packageStatus();
+
+            if ($status === 'pending' && $date) {
+                $ts = strtotime($date);
+                if ($ts >= $today) {
+                    $data[] = [
+                        'uuid'        => $Package->uuid(),
+                        'packageDate' => $date,
+                        'due'         => ($ts <= $today ? 1 : 0),
+                    ];
+                }
+            }
+        }
+    }
+
+    $Template = new PerchTemplate('shop/' . $opts['template']);
+    $r        = $Template->render(['packages' => $data]);
 
     if ($return) {
         return $r;

--- a/perch/templates/pages/client/order.php
+++ b/perch/templates/pages/client/order.php
@@ -63,7 +63,15 @@ echo '<div class="plan">
                   }    }  ?>
 
 
-</div></div>
+        </div></div>
+
+        <div class="container all_content mt-4">
+            <h2 class="text-center fw-bolder">Future Payments</h2>
+
+            <div class="plans mt-4">
+                <?php perch_shop_future_packages(); ?>
+            </div>
+        </div>
 
 </section>
 

--- a/perch/templates/pages/order/package-builder.php
+++ b/perch/templates/pages/order/package-builder.php
@@ -40,21 +40,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     if ($package) {
 
                     $_SESSION['perch_shop_package_id']= $_SESSION['draft_package']['id'];
-                    print_r($_SESSION['draft_package']['selections']);
+                    $_SESSION['package_billing_type'] = $_SESSION['draft_package']['billing'];
                     perch_shop_add_package_item($package->id(), $_SESSION['draft_package']['selections']);
                           unset($_SESSION['draft_package']);
                             //$draft = null;
 
                     }
 
-echo "db crsyion";
-
- echo "perch_shop_package_id";
- echo $_SESSION['perch_shop_package_id'];
+// Debug output removed
         // Optional: redirect to a confirmation screen
       header('Location: /order/package-summary'); exit;
     } else {
-    echo "posts";print_r($_POST);
         // Create/attach a draft ID
         $posted_id = isset($_POST['package_id']) ? (string)$_POST['package_id'] : null;
 
@@ -119,8 +115,6 @@ echo "db crsyion";
         --------------------------------------------------------- */
 
         $_SESSION['draft_package'] = $draft;
-        echo "draft_package crsyion";
-        print_r($_SESSION['draft_package']);
     }
 }
 

--- a/perch/templates/pages/order/package-summary.php
+++ b/perch/templates/pages/order/package-summary.php
@@ -1,7 +1,9 @@
 <?php  if (session_status() === PHP_SESSION_NONE) {
               session_start();
-          } //include('../perch/runtime.php');
-print_r($_SESSION);
+          }
+if (!isset($_SESSION['perch_shop_package_id']) && isset($_GET['package'])) {
+    $_SESSION['perch_shop_package_id'] = $_GET['package'];
+} //include('../perch/runtime.php');
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $quantities = perch_post('qty');
     $removals = perch_post('remove');
@@ -18,11 +20,32 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
     if (perch_post('action') === 'checkout') {
+        $is_reorder = customer_has_paid_order();
+        if ($is_reorder) {
+            if (empty($_SESSION['questionnaire-reorder'])) {
+                PerchUtil::redirect('/order/re-order');
+            }
+        } else {
+            if (empty($_SESSION['questionnaire'])) {
+                PerchUtil::redirect('/getStarted');
+            }
+        }
         try {
             $package = perch_shop_update_package_status("confirmed");
             if ($package) {
-            echo "checkout";print_r($package);
-              //  $result= perch_shop_add_to_cart($_POST["dose"]);
+                $billing = $_SESSION['package_billing_type'] ?? 'prepaid';
+                $items   = $package->get_items();
+                if (is_array($items)) {
+                    foreach ($items as $Item) {
+                        if ($billing === 'monthly' && (int)$Item->month() > 1) {
+                            continue;
+                        }
+                        $productID = $Item->variantID() ? $Item->variantID() : $Item->productID();
+                        if ($productID) {
+                            perch_shop_add_to_cart($productID, $Item->qty());
+                        }
+                    }
+                }
                 PerchUtil::redirect('checkout.php');
             }
         } catch (Exception $e) {

--- a/perch/templates/shop/packages/future.html
+++ b/perch/templates/shop/packages/future.html
@@ -1,0 +1,19 @@
+<perch:if exists="packages">
+    <perch:packages>
+        <div class="plan">
+            <div>
+                <h5>Payment Date</h5>
+                <p><perch:package id="packageDate" /></p>
+            </div>
+            <div>
+                <perch:if id="due" match="eq" value="1">
+                    <a class="button" href="/order/package-summary.php?package=<perch:package id='uuid' />">Checkout</a>
+                <perch:else />
+                    <p>Upcoming</p>
+                </perch:if>
+            </div>
+        </div>
+    </perch:packages>
+<perch:else />
+    <p>No future payments scheduled.</p>
+</perch:if>


### PR DESCRIPTION
## Summary
- expose package date, status, and uuid fields on package model
- add runtime helper and template to list upcoming package payments with checkout link when due
- show future payments section on client order page and allow summary to accept package UUID
- remove leftover debug statements from package builder
- redirect customers to appropriate questionnaire before checkout depending on order history

## Testing
- `php -l perch/addons/apps/perch_shop/runtime/packages.php`
- `php -l perch/addons/apps/perch_shop/lib/PerchShop_Packages.class.php`
- `php -l perch/templates/pages/client/order.php`
- `php -l perch/templates/pages/order/package-builder.php`
- `php -l perch/templates/pages/order/package-summary.php`


------
https://chatgpt.com/codex/tasks/task_b_68b97aca839c8324bd7efb49d5fb77e4