### PR TITLE
Add payment notification helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-test
+# Weightloss Project
+
+This repository contains various PHP scripts for managing packages.
+
+## Payment Scheduler
+
+`next_payment_scheduler.php` provides a helper function to determine the next payment
+for a monthly subscription package. You can run it from the command line:
+
+```
+php next_payment_scheduler.php 2023-01-15
+```
+
+This outputs the date when the next payment is due.
+
+## Payment Notifications
+
+`send_payment_notification.php` scans the `shop_packages` table for
+pending packages with a `nextBillingDate` one week in the future and uses
+Perch's email library to notify the associated customers.
+
+Run the script from the command line:
+
+```
+php send_payment_notification.php
+```
+
+Each matching customer receives an email reminder to complete the payment
+from their portal.
+
+## Advancing Billing Dates
+
+After recording a payment, run `advance_next_billing.php` to move the
+package's `nextBillingDate` forward by one month:
+
+```
+php advance_next_billing.php <packageID>
+```
+
+This keeps the package's billing cycle up to date.

--- a/advance_next_billing.php
+++ b/advance_next_billing.php
@@ -1,0 +1,37 @@
+<?php
+
+require_once __DIR__ . '/perch/runtime.php';
+require_once __DIR__ . '/next_payment_scheduler.php';
+
+if (PHP_SAPI !== 'cli') {
+    exit; // Only allow CLI usage
+}
+
+if ($argc < 2) {
+    fwrite(STDERR, "Usage: php advance_next_billing.php <packageID>\n");
+    exit(1);
+}
+
+$API = new PerchAPI(1.0, 'perch_shop');
+$DB  = PerchDB::fetch();
+
+$packageID = (int)$argv[1];
+$table     = PERCH_DB_PREFIX . 'shop_packages';
+
+// Fetch current nextBillingDate for the package
+$sql    = 'SELECT nextBillingDate FROM ' . $table . ' WHERE packageID=' . $DB->pdb($packageID);
+$record = $DB->get_row($sql);
+
+if (!$record || empty($record['nextBillingDate'])) {
+    fwrite(STDERR, "Package not found or nextBillingDate missing\n");
+    exit(1);
+}
+
+$lastBilling = new DateTimeImmutable($record['nextBillingDate']);
+$nextBilling = nextMonthlyPayment($lastBilling)->format('Y-m-d');
+
+$update = 'UPDATE ' . $table . ' SET nextBillingDate=' . $DB->pdb($nextBilling)
+    . ' WHERE packageID=' . $DB->pdb($packageID);
+$DB->execute($update);
+
+echo "nextBillingDate set to {$nextBilling} for package {$packageID}" . PHP_EOL;

--- a/next_payment_scheduler.php
+++ b/next_payment_scheduler.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Calculate next payment date for monthly packages.
+ *
+ * This helper assumes that payments recur every month on the same day.
+ * If the subsequent month has fewer days and the original payment was on
+ * a day that doesn't exist in the new month (e.g. Jan 31 -> Feb), the date
+ * will roll over to the last day of the month.
+ *
+ * @param \DateTimeInterface $lastPayment Date of the most recent payment.
+ * @return \DateTimeImmutable Date when the next payment is due.
+ */
+function nextMonthlyPayment(\DateTimeInterface $lastPayment): \DateTimeImmutable
+{
+    // Clone the date to avoid modifying the original instance
+    $date = \DateTimeImmutable::createFromFormat('Y-m-d', $lastPayment->format('Y-m-d'));
+
+    // Add one month; PHP takes care of month-end edge cases
+    return $date->modify('+1 month');
+}
+
+// If executed directly from the CLI (not when included), accept an input date
+// and output the next due date.
+if (
+    PHP_SAPI === 'cli'
+    && realpath($_SERVER['SCRIPT_FILENAME']) === __FILE__
+    && isset($argv[1])
+) {
+    $input = new \DateTimeImmutable($argv[1]);
+    echo nextMonthlyPayment($input)->format('Y-m-d') . PHP_EOL;
+}

--- a/perch/addons/apps/perch_shop/db_updates.sql
+++ b/perch/addons/apps/perch_shop/db_updates.sql
@@ -28,9 +28,13 @@ CREATE TABLE IF NOT EXISTS `__PREFIX__shop_packages` (
   `customerID` int(10) unsigned NOT NULL DEFAULT '0',
   `month` char(7) NOT NULL DEFAULT '',
   `status` char(32) NOT NULL DEFAULT '',
+  `nextBillingDate` date DEFAULT NULL,
   PRIMARY KEY (`packageID`),
   KEY `idx_customer` (`customerID`)
 ) CHARSET=utf8;
+
+ALTER TABLE `__PREFIX__shop_packages`
+  ADD COLUMN IF NOT EXISTS `nextBillingDate` date DEFAULT NULL AFTER `status`;
 
 CREATE TABLE IF NOT EXISTS `__PREFIX__shop_package_items` (
   `itemID` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/perch/addons/apps/perch_shop/lib/PerchShop_Packages.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Packages.class.php
@@ -5,8 +5,8 @@ class PerchShop_Packages extends PerchShop_Factory
     public $api_method         = 'packages';
     public $api_list_method    = 'packages';
     public $singular_classname = 'PerchShop_Package';
-    public $static_fields      = ['customerID', 'month', 'status', 'packageDate', 'packageStatus', 'uuid'];
-    public $remote_fields      = ['customerID', 'month', 'status', 'packageDate', 'packageStatus', 'uuid'];
+    public $static_fields      = ['customerID', 'month', 'status', 'packageDate', 'packageStatus', 'uuid', 'nextBillingDate'];
+    public $remote_fields      = ['customerID', 'month', 'status', 'packageDate', 'packageStatus', 'uuid', 'nextBillingDate'];
 
     protected $table               = 'shop_packages';
     protected $pk                  = 'packageID';

--- a/send_payment_notification.php
+++ b/send_payment_notification.php
@@ -1,0 +1,34 @@
+<?php
+
+require_once __DIR__ . '/perch/runtime.php';
+
+$API       = new PerchAPI(1.0, 'perch_shop');
+$DB        = PerchDB::fetch();
+$Customers = new PerchShop_Customers($API);
+
+$table  = PERCH_DB_PREFIX . 'shop_packages';
+$target = (new DateTimeImmutable('+1 week'))->format('Y-m-d');
+
+$sql = 'SELECT customerID, nextBillingDate FROM ' . $table .
+       ' WHERE status=' . $DB->pdb('pending') .
+       ' AND nextBillingDate=' . $DB->pdb($target);
+
+$packages = $DB->get_rows($sql);
+
+if (PerchUtil::count($packages)) {
+    foreach ($packages as $package) {
+        $Customer = $Customers->find((int)$package['customerID']);
+        if (!$Customer) {
+            continue;
+        }
+
+        $Email = new PerchEmail('');
+        $Email->subject('Upcoming Payment Reminder');
+        $Email->senderName('Weightloss');
+        $Email->senderEmail('no-reply@example.com');
+        $Email->recipientEmail($Customer->customerEmail());
+        $Email->body('Your next payment is due on ' . $package['nextBillingDate'] . '. Please complete it from your portal.');
+        $Email->send();
+    }
+}
+


### PR DESCRIPTION
## Summary
- track next billing date for packages
- notify customers a week before payment via PerchEmail
- advance nextBillingDate after payments with a new CLI helper
- document package notification and billing update scripts

## Testing
- `php -l advance_next_billing.php` *(fails: php: No such file or directory)*
- `php -l next_payment_scheduler.php` *(fails: php: No such file or directory)*
- `php -l send_payment_notification.php` *(fails: php: No such file or directory)*
- `/bin/apt-get update` *(fails: repositories not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_b_68baa987a9cc8324b5676954d43d8b35