### PR TITLE
Skip payment gateway for zero total orders

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
@@ -84,14 +84,16 @@ class PerchShop_Order extends PerchShop_Base
     }
 
 
-	public function take_payment($method='purchase', $opts=array())
-	{
-	//print_r($this->orderGateway());
-		$Gateway = PerchShop_Gateways::get($this->orderGateway());
-		$result  = $Gateway->take_payment($this, $opts);
-
-		return false;
-	}
+        public function take_payment($method='purchase', $opts=array())
+        {
+        //print_r($this->orderGateway());
+                if ((float)$this->orderTotal() <= 0) {
+                        $this->finalize_as_paid('pending');
+                        return true;
+                }
+                $Gateway = PerchShop_Gateways::get($this->orderGateway());
+                return $Gateway->take_payment($this, $opts);
+        }
 
 	public function complete_payment($args, $gateway_opts=array())
 	{


### PR DESCRIPTION
## Summary
- Skip gateway call and finalize as pending when an order total is zero
- Return gateway result so successful transitions are reported

## Testing
- `php -l perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php`

------
https://chatgpt.com/codex/tasks/task_b_68bae9f60088832495c97a77061332da