### PR TITLE
Add admin page listing package future payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ php advance_next_billing.php <packageID>
 ```
 
 This keeps the package's billing cycle up to date.
+
+## Package Report
+
+In the admin interface, under the Orders section, use the **Package Report** link to view upcoming payments. The report lists each package along with its customer ID, status, and next billing date.

--- a/perch/addons/apps/perch_shop_orders/modes/_subnav.php
+++ b/perch/addons/apps/perch_shop_orders/modes/_subnav.php
@@ -1,18 +1,19 @@
 <?php
-	PerchUI::set_subnav([
-		['page'=>[
-						'perch_shop_orders',
-						'perch_shop_orders/order',
-						'perch_shop_orders/order/edit',
-						'perch_shop_orders/order/evidence',
-						'perch_shop_orders/export',
-						], 
-				'label'=>'Orders'],
-		['page'=>[
-						'perch_shop_orders/customers',
-						'perch_shop_orders/customers/edit',
-						'perch_shop_orders/customers/delete',
-						], 
-				'label'=>'Customers']
+        PerchUI::set_subnav([
+                ['page'=>[
+                                                'perch_shop_orders',
+                                                'perch_shop_orders/order',
+                                                'perch_shop_orders/order/edit',
+                                                'perch_shop_orders/order/evidence',
+                                                'perch_shop_orders/export',
+                                                ],
+                                'label'=>'Orders'],
+                ['page'=>[
+                                                'perch_shop_orders/customers',
+                                                'perch_shop_orders/customers/edit',
+                                                'perch_shop_orders/customers/delete',
+                                                ],
+                                'label'=>'Customers'],
+                ['page'=>'../../package_report.php', 'label'=>'Package Report'],
+        ], $CurrentUser);
 
-	], $CurrentUser);

--- a/perch/package_report.php
+++ b/perch/package_report.php
@@ -1,0 +1,50 @@
+<?php
+require_once __DIR__ . '/runtime.php';
+
+$API = new PerchAPI(1.0, 'perch_shop');
+$DB  = PerchDB::fetch();
+
+$table = PERCH_DB_PREFIX . 'shop_packages';
+$sql   = 'SELECT packageID, customerID, status, nextBillingDate FROM ' . $table . ' ORDER BY nextBillingDate ASC';
+
+$packages = $DB->get_rows($sql);
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Package Future Payments</title>
+    <style>
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+        th { background: #f5f5f5; }
+    </style>
+</head>
+<body>
+    <h1>Package Future Payments</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>Package ID</th>
+                <th>Customer ID</th>
+                <th>Status</th>
+                <th>Next Billing Date</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if (PerchUtil::count($packages)) : ?>
+            <?php foreach ($packages as $pkg): ?>
+                <tr>
+                    <td><?= (int)$pkg['packageID'] ?></td>
+                    <td><?= (int)$pkg['customerID'] ?></td>
+                    <td><?= htmlspecialchars($pkg['status']) ?></td>
+                    <td><?= htmlspecialchars($pkg['nextBillingDate']) ?></td>
+                </tr>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <tr><td colspan="4">No packages found</td></tr>
+        <?php endif; ?>
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `perch/package_report.php` to list packages and upcoming billing dates
- Link the package report under the Orders menu in the admin
- Document how to access the package report from the Orders section

## Testing
- `php -l perch/addons/apps/perch_shop_orders/modes/_subnav.php`
- `php -l perch/package_report.php`


------
https://chatgpt.com/codex/tasks/task_b_68bbea0cb20883249f1c24d324713b41