### PR TITLE
Add push notification inbox API

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,13 @@ This keeps the package's billing cycle up to date.
 ## Package Report
 
 In the admin interface, under the Orders section, use the **Package Report** link to view upcoming payments. The report lists each package along with its customer ID, status, and next billing date.
+
+## Push Notifications Inbox
+
+Clients can view push notifications via the `/api/notifications` endpoint. The endpoint returns a list of messages for the authenticated member, including title, message body, timestamp, and read state, enabling an inbox within the client portal.
+
+The client portal exposes these messages at `/client/notifications`, rendering a simple list of a member's alerts.
+Unread notifications display a red dot indicator and are marked as read when the list is viewed.
+
+To create a new notification in code, call `perch_member_add_notification($memberID, $title, $message)`.
+

--- a/perch/addons/apps/api/routes/notifications.php
+++ b/perch/addons/apps/api/routes/notifications.php
@@ -1,0 +1,23 @@
+<?php
+include(__DIR__ .'/../../../../core/runtime/runtime.php');
+
+require_once __DIR__ . '/../auth.php';
+
+$token = get_bearer_token();
+$payload = verify_token($token);
+
+if (!$payload) {
+    http_response_code(401);
+    echo json_encode(["error" => "Unauthorized"]);
+    exit;
+}
+
+$notifications = perch_member_notifications($payload['user_id']);
+
+if ($notifications) {
+    echo json_encode($notifications);
+} else {
+    http_response_code(404);
+    echo json_encode(["error" => "Notifications not found"]);
+}
+

--- a/perch/addons/apps/perch_members/PerchMembers_Notification.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Notification.class.php
@@ -1,0 +1,8 @@
+<?php
+
+class PerchMembers_Notification extends PerchAPI_Base
+{
+    protected $table = 'members_notifications';
+    protected $pk    = 'notificationID';
+}
+

--- a/perch/addons/apps/perch_members/PerchMembers_Notifications.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Notifications.class.php
@@ -1,0 +1,21 @@
+<?php
+
+class PerchMembers_Notifications extends PerchAPI_Factory
+{
+    protected $table               = 'members_notifications';
+    protected $pk                  = 'notificationID';
+    protected $singular_classname  = 'PerchMembers_Notification';
+    protected $default_sort_column = 'notificationDate';
+    public $static_fields = ['notificationID','memberID','notificationTitle','notificationMessage','notificationDate','notificationRead'];
+
+    public function get_for_member($memberID)
+    {
+        $sql = 'SELECT n.*
+                FROM '.PERCH_DB_PREFIX.'members_notifications n
+                WHERE n.memberID='.$this->db->pdb((int)$memberID).'
+                ORDER BY n.notificationDate DESC';
+
+        return $this->return_instances($this->db->get_rows($sql));
+    }
+}
+

--- a/perch/templates/layouts/client/header.php
+++ b/perch/templates/layouts/client/header.php
@@ -75,6 +75,14 @@
           border-color: #007bff;
           background-color: #fff;
         }
+        .unread-dot {
+          display: inline-block;
+          width: 8px;
+          height: 8px;
+          background: #dc3545;
+          border-radius: 50%;
+          margin-left: 4px;
+        }
       </style>
          <?php if (perch_member_logged_in()) { ?>
    <div class="subheader">
@@ -92,6 +100,14 @@
       $reorder_tab="";
        $documents_tab="";
         $affiliate_tab="";
+        $notifications_tab="";
+        $unread_count=0;
+        $member_notifications = perch_member_notifications();
+        if ($member_notifications) {
+            foreach ($member_notifications as $n) {
+                if (!$n['read']) $unread_count++;
+            }
+        }
   if($lastPart=="client"){
   $profile_tab="active";
   }else if( $lastPart=="orders" ){
@@ -103,6 +119,8 @@
            }else if($lastPart=="affiliate-dashboard" ){
 
            $affiliate_tab="active";
+           }else if($lastPart=="notifications" ){
+            $notifications_tab="active";
            }
       ?>
      <div class="tabs">
@@ -110,6 +128,7 @@
                      <a href="/payment/success" class="tab <?php echo $documents_tab; ?>">Documents</a>
 
        <a href="/client/orders" class="tab <?php echo $orders_tab; ?>">Orders</a>
+       <a href="/client/notifications" class="tab <?php echo $notifications_tab; ?>">Notifications<?php if($unread_count){?><span class="unread-dot"></span><?php } ?></a>
        <a href="/client/affiliate-dashboard" class="tab <?php echo $affiliate_tab; ?>">Affiliate</a>
        <a href="/order/re-order" class="tab <?php echo $reorder_tab; ?>">Order</a>
        <a href="/client/logout" class="tab ">Logout</a>

--- a/perch/templates/pages/client/notifications.php
+++ b/perch/templates/pages/client/notifications.php
@@ -1,0 +1,33 @@
+<?php
+// Output the top of the page
+perch_layout('client/header', [
+    'page_title' => perch_page_title(true),
+]);
+
+$notifications = perch_member_notifications();
+if ($notifications) {
+    perch_member_mark_notifications_read();
+}
+?>
+
+<section class="main_order_summary">
+    <div class="container mt-5">
+        <h2>Your Notifications</h2>
+        <?php if ($notifications) { ?>
+            <ul class="list-group">
+                <?php foreach ($notifications as $n) { ?>
+                    <li class="list-group-item">
+                        <?php if (!$n['read']) { ?><span class="unread-dot"></span><?php } ?>
+                        <strong><?php echo htmlspecialchars($n['title']); ?></strong>
+                        <p><?php echo htmlspecialchars($n['message']); ?></p>
+                        <small class="text-muted"><?php echo htmlspecialchars($n['date']); ?></small>
+                    </li>
+                <?php } ?>
+            </ul>
+        <?php } else { ?>
+            <p>No notifications.</p>
+        <?php } ?>
+    </div>
+</section>
+
+<?php perch_layout('getStarted/footer'); ?>


### PR DESCRIPTION
## Summary
- add notification model classes for storing member alerts
- expose `/api/notifications` endpoint to list a member's push notifications
- document the new push notification inbox endpoint
- add `perch_member_add_notification()` helper to create notifications
- surface member notifications at `/client/notifications` via a new navigation tab
- highlight unread notifications with a red dot and mark them read on view

## Testing
- `php -l perch/addons/apps/perch_members/PerchMembers_Notification.class.php`
- `php -l perch/addons/apps/perch_members/PerchMembers_Notifications.class.php`
- `php -l perch/addons/apps/perch_members/runtime.php`
- `php -l perch/addons/apps/api/routes/notifications.php`
- `php -l perch/templates/layouts/client/header.php`
- `php -l perch/templates/pages/client/notifications.php`


------
https://chatgpt.com/codex/tasks/task_b_68bbfa1778c8832489c64b2f3c113a16