### PR TITLE
Persist package and questionnaire data via cookies

### DIFF
--- a/perch/templates/pages/client/reorder-questionnaire.php
+++ b/perch/templates/pages/client/reorder-questionnaire.php
@@ -1,5 +1,10 @@
- <?php  if (!perch_member_logged_in()) { exit;}
-     //  echo "session";
+<?php
+if (session_status() === PHP_SESSION_NONE) session_start();
+if (!perch_member_logged_in()) { exit;}
+if (empty($_SESSION['questionnaire-reorder']) && isset($_COOKIE['questionnaire_reorder'])) {
+    $_SESSION['questionnaire-reorder'] = json_decode($_COOKIE['questionnaire_reorder'], true) ?: [];
+}
+    //  echo "session";
       //  print_r($_SESSION);
  function generateUUID() {
      return sprintf(
@@ -43,7 +48,8 @@
                    }
                      logAnswerChange($key, $_SESSION['questionnaire-reorder'][$key],"reorder");
          }
-         //print_r($_SESSION['reorder_answer_log']);
+        setcookie('questionnaire_reorder', json_encode($_SESSION['questionnaire-reorder']), time()+3600, '/');
+        //print_r($_SESSION['reorder_answer_log']);
 
      if($_POST['nextstep']=="cart"){
 
@@ -107,11 +113,12 @@
                             header("Location: /order/cart"); // Redirect to the selected URL
                                               exit();
                                  }else{
-                                  header("Location: /client/questionnaire-re-order?step=".$_POST['nextstep'] ); // Redirect to the selected URL
+                                header("Location: /client/questionnaire-re-order?step=".$_POST['nextstep'] ); // Redirect to the selected URL
                                     exit();
                                     }
 
     }
+    setcookie('questionnaire_reorder', json_encode($_SESSION['questionnaire-reorder'] ?? []), time()+3600, '/');
         perch_layout('getStarted/header', [
             'page_title' => perch_page_title(true),
         ]);

--- a/perch/templates/pages/getStarted/questionnaire.php
+++ b/perch/templates/pages/getStarted/questionnaire.php
@@ -1,4 +1,5 @@
 <?php
+if (session_status() === PHP_SESSION_NONE) session_start();
 
 /*
 function generateUUID() {
@@ -141,10 +142,18 @@ function generateUUID() {
     );
 }
 
+$cookieQuestionnaire = isset($_COOKIE['questionnaire'])
+    ? json_decode($_COOKIE['questionnaire'], true)
+    : [];
+if (!isset($_SESSION['questionnaire']) || empty($_SESSION['questionnaire'])) {
+    $_SESSION['questionnaire'] = $cookieQuestionnaire;
+}
+
 $previousPage = $_SERVER['HTTP_REFERER'] ?? 'No referrer';
 $redirect=true;
 if (isset($_GET['step']) && $_GET['step'] === 'startagain') {
     $_SESSION['questionnaire'] = [];
+    setcookie('questionnaire', '', time()-3600, '/');
     header("Location: /get-started/questionnaire?step=howold");
     exit();
 }
@@ -240,6 +249,7 @@ if (isset($_POST['nextstep'])) {
     $redirectUrl = ($nextStep === 'plans')
         ? "/get-started/review-questionnaire"
         : "/get-started/questionnaire?step=$nextStep";
+    setcookie('questionnaire', json_encode($_SESSION['questionnaire']), time()+3600, '/');
        /* if($_SESSION['questionnaire']['reviewed'] === 'InProcess' && $nextStep=="plans" ){
         exit;
         }else{
@@ -253,6 +263,7 @@ if (isset($_POST['nextstep'])) {
             }
 
 }
+setcookie('questionnaire', json_encode($_SESSION['questionnaire'] ?? []), time()+3600, '/');
 ?>
 
 

--- a/perch/templates/pages/getStarted/review-questionnaire.php
+++ b/perch/templates/pages/getStarted/review-questionnaire.php
@@ -1,4 +1,8 @@
 <?php
+if (session_status() === PHP_SESSION_NONE) session_start();
+if (empty($_SESSION['questionnaire']) && isset($_COOKIE['questionnaire'])) {
+    $_SESSION['questionnaire'] = json_decode($_COOKIE['questionnaire'], true) ?: [];
+}
 $questions = [
     "age" => "How old are you?",
     "ethnicity" => "Which ethnicity are you?",
@@ -73,6 +77,7 @@ function renderMeasurement($value, $unitKey, $secondKey, $questionnaire) {
 }
 
 // Page header
+setcookie('questionnaire', json_encode($_SESSION['questionnaire'] ?? []), time()+3600, '/');
 perch_layout('product/header', [
     'page_title' => perch_page_title(true),
 ]);

--- a/perch/templates/pages/order/cart.php
+++ b/perch/templates/pages/order/cart.php
@@ -1,4 +1,12 @@
- <?php   if (perch_member_logged_in() && perch_shop_addresses_set() && isset($_SESSION["package_billing_type"])) {
+ <?php
+if (session_status() === PHP_SESSION_NONE) session_start();
+if (!isset($_SESSION['questionnaire']) && isset($_COOKIE['questionnaire'])) {
+    $_SESSION['questionnaire'] = json_decode($_COOKIE['questionnaire'], true) ?: [];
+}
+if (!isset($_SESSION['questionnaire-reorder']) && isset($_COOKIE['questionnaire_reorder'])) {
+    $_SESSION['questionnaire-reorder'] = json_decode($_COOKIE['questionnaire_reorder'], true) ?: [];
+}
+if (perch_member_logged_in() && perch_shop_addresses_set() && isset($_SESSION["package_billing_type"])) {
             $is_reorder = customer_has_paid_order();
 
                              if ($is_reorder) {
@@ -12,6 +20,8 @@
                              }
            }
 
+setcookie('questionnaire', json_encode($_SESSION['questionnaire'] ?? []), time()+3600, '/');
+setcookie('questionnaire_reorder', json_encode($_SESSION['questionnaire-reorder'] ?? []), time()+3600, '/');
   print_r($_SESSION);
     // output the top of the page
      perch_layout('product/header', [
@@ -29,6 +39,7 @@
 
             if(isset($_POST["dose"])){
                 $_SESSION['questionnaire-reorder']["dose"] = $_POST["dose"];
+                setcookie('questionnaire_reorder', json_encode($_SESSION['questionnaire-reorder']), time()+3600, '/');
                $result= perch_shop_add_to_cart($_POST["dose"]);
                echo "<script>window.location.href='/client/questionnaire-re-order?step=weight';</script> ";
                exit;

--- a/perch/templates/pages/order/index.php
+++ b/perch/templates/pages/order/index.php
@@ -1,5 +1,11 @@
-<?php if(isset($_SESSION['questionnaire'])) {$errors =perch_member_validateQuestionnaire($_SESSION['questionnaire']) ;
+<?php
+if (session_status() === PHP_SESSION_NONE) session_start();
+if (!isset($_SESSION['questionnaire']) && isset($_COOKIE['questionnaire'])) {
+    $_SESSION['questionnaire'] = json_decode($_COOKIE['questionnaire'], true) ?: [];
+}
+if(isset($_SESSION['questionnaire'])) {$errors =perch_member_validateQuestionnaire($_SESSION['questionnaire']) ;
  if (!empty($errors)) {header("Location: /get-started/review-questionnaire");    }}else{header("Location: /get-started");}
+setcookie('questionnaire', json_encode($_SESSION['questionnaire'] ?? []), time()+3600, '/');
 
 
  // output the top of the page
@@ -14,9 +20,10 @@
     <div class="main_product">
         <div id="product-selection">
 <?php
- if(isset($_POST["confirm"]) || $_SESSION['questionnaire']["confirmed"]){
+if(isset($_POST["confirm"]) || $_SESSION['questionnaire']["confirmed"]){
 $_SESSION['questionnaire']["confirmed"] = true;
 $_SESSION['questionnaire']["reviewed"] = "Completed";
+setcookie('questionnaire', json_encode($_SESSION['questionnaire']), time()+3600, '/');
 
     if (empty($errors)) {
 

--- a/perch/templates/pages/order/package-summary.php
+++ b/perch/templates/pages/order/package-summary.php
@@ -2,12 +2,19 @@
               session_start();
           }
           $_SESSION['perch_shop_package_monthly_checkout'] = false;
+          if (!isset($_SESSION['perch_shop_package_id']) && isset($_COOKIE['perch_shop_package_id'])) {
+            $_SESSION['perch_shop_package_id'] = $_COOKIE['perch_shop_package_id'];
+          }
+          if (!isset($_SESSION['package_billing_type']) && isset($_COOKIE['package_billing_type'])) {
+            $_SESSION['package_billing_type'] = $_COOKIE['package_billing_type'];
+          }
           if(isset($_GET['package'])){
             $_SESSION['perch_shop_package_monthly_checkout'] = true;
           }
 
 if (!isset($_SESSION['perch_shop_package_id']) && isset($_GET['package'])) {
     $_SESSION['perch_shop_package_id'] = $_GET['package'];
+    setcookie('perch_shop_package_id', $_GET['package'], time()+3600, '/');
 } //include('../perch/runtime.php');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/perch/templates/pages/payment/stripe/index.php
+++ b/perch/templates/pages/payment/stripe/index.php
@@ -1,6 +1,13 @@
 <?php //include('../../perch/runtime.php');?>
 
 <?php
+if (session_status() === PHP_SESSION_NONE) session_start();
+if (empty($_SESSION['questionnaire']) && isset($_COOKIE['questionnaire'])) {
+    $_SESSION['questionnaire'] = json_decode($_COOKIE['questionnaire'], true) ?: [];
+}
+if (empty($_SESSION['questionnaire-reorder']) && isset($_COOKIE['questionnaire_reorder'])) {
+    $_SESSION['questionnaire-reorder'] = json_decode($_COOKIE['questionnaire_reorder'], true) ?: [];
+}
 
       // your 'success' and 'failure' URLs
     $success_url= "https://".$_SERVER['HTTP_HOST']."/payment/success";
@@ -13,11 +20,12 @@
        ]);
 
 
-	if ($result) {
-	if(isset($_SESSION['questionnaire-reorder']) && !empty($_SESSION['questionnaire-reorder'])){
-	unset($_SESSION['questionnaire-reorder']['nextstep']);
+        if ($result) {
+        if(isset($_SESSION['questionnaire-reorder']) && !empty($_SESSION['questionnaire-reorder'])){
+        unset($_SESSION['questionnaire-reorder']['nextstep']);
     perch_member_add_questionnaire($_SESSION['questionnaire-reorder'],'re-order');
     $_SESSION['questionnaire-reorder'] = array();
+    setcookie('questionnaire_reorder', '', time()-3600, '/');
     }
      // perch_shop_shipping_method_form();
             // $stripeform=true;
@@ -80,11 +88,14 @@
              unset($_SESSION['answer_log']);
              }
 
-              $_SESSION['questionnaire'] = array();
+             $_SESSION['questionnaire'] = array();
+            setcookie('questionnaire', '', time()-3600, '/');
             }
 
-		   echo("<script>location.href = '".$success_url."';</script>");
-		}else{
-		   echo("<script>location.href = '".$cancel_url."';</script>");
-		}
+                   echo("<script>location.href = '".$success_url."';</script>");
+                }else{
+                   setcookie('questionnaire_reorder', json_encode($_SESSION['questionnaire-reorder'] ?? []), time()+3600, '/');
+                   setcookie('questionnaire', json_encode($_SESSION['questionnaire'] ?? []), time()+3600, '/');
+                   echo("<script>location.href = '".$cancel_url."';</script>");
+                }
 ?>


### PR DESCRIPTION
## Summary
- use cookies instead of PHP sessions to store draft package data and questionnaire progress
- recover package and questionnaire identifiers from cookies across pages

## Testing
- `php -l perch/templates/pages/getStarted/questionnaire.php`
- `php -l perch/templates/pages/client/reorder-questionnaire.php`
- `php -l perch/templates/pages/payment/stripe/index.php`
- `php -l perch/templates/pages/getStarted/review-questionnaire.php`
- `php -l perch/templates/pages/order/index.php`
- `php -l perch/templates/pages/order/cart.php`


------
https://chatgpt.com/codex/tasks/task_b_68bfeb8a7d84832496c63afae5799c51