### PR TITLE
Add admin UI for product-pharmacy mappings

### DIFF
--- a/perch/addons/apps/perch_products_match_pharmacy/_default_index.php
+++ b/perch/addons/apps/perch_products_match_pharmacy/_default_index.php
@@ -1,0 +1,16 @@
+<?php
+    include(__DIR__.'/../../../core/inc/api.php');
+
+    $API  = new PerchAPI(1.0, 'perch_products_match_pharmacy');
+    $Lang = $API->get('Lang');
+    $HTML = $API->get('HTML');
+    $Paging = $API->get('Paging');
+
+    $Perch->page_title = $Lang->get($title);
+
+    include('modes/_subnav.php');
+    include('modes/'.$mode.'.pre.php');
+
+    include(PERCH_CORE . '/inc/top.php');
+    include('modes/'.$mode.'.post.php');
+    include(PERCH_CORE . '/inc/btm.php');

--- a/perch/addons/apps/perch_products_match_pharmacy/admin.php
+++ b/perch/addons/apps/perch_products_match_pharmacy/admin.php
@@ -1,0 +1,4 @@
+<?php
+if ($CurrentUser->logged_in()) {
+    $this->register_app('perch_products_match_pharmacy', 'Product Pharmacy Matches', 1, 'Match products to pharmacy equivalents', '1.0');
+}

--- a/perch/addons/apps/perch_products_match_pharmacy/index.php
+++ b/perch/addons/apps/perch_products_match_pharmacy/index.php
@@ -1,0 +1,4 @@
+<?php
+    $mode  = 'mappings.list';
+    $title = 'Product Pharmacy Matches';
+    include('_default_index.php');

--- a/perch/addons/apps/perch_products_match_pharmacy/modes/_subnav.php
+++ b/perch/addons/apps/perch_products_match_pharmacy/modes/_subnav.php
@@ -1,0 +1,4 @@
+<?php
+    echo $HTML->subnav([
+        ['page' => $API->app_path(), 'label' => 'Listings'],
+    ], $CurrentUser);

--- a/perch/addons/apps/perch_products_match_pharmacy/modes/mapping.delete.post.php
+++ b/perch/addons/apps/perch_products_match_pharmacy/modes/mapping.delete.post.php
@@ -1,0 +1,3 @@
+<?php
+    // Intentionally left blank as redirect happens in pre
+?>

--- a/perch/addons/apps/perch_products_match_pharmacy/modes/mapping.delete.pre.php
+++ b/perch/addons/apps/perch_products_match_pharmacy/modes/mapping.delete.pre.php
@@ -1,0 +1,8 @@
+<?php
+    $DB = $API->get('DB');
+    $id = (int) PerchUtil::get('id');
+    if ($id) {
+        $sql = 'DELETE FROM '.PERCH_DB_PREFIX.'products_match_pharmacy WHERE id=' . $DB->pdb($id) . ' LIMIT 1';
+        $DB->execute($sql);
+    }
+    PerchUtil::redirect($API->app_path());

--- a/perch/addons/apps/perch_products_match_pharmacy/modes/mapping.edit.post.php
+++ b/perch/addons/apps/perch_products_match_pharmacy/modes/mapping.edit.post.php
@@ -1,0 +1,14 @@
+<?php
+    echo $HTML->title_panel([
+        'heading' => $Lang->get('Edit Mapping')
+    ], $CurrentUser);
+
+    if ($message) echo $message;
+
+    echo $Form->form_start();
+    echo $Form->text_field('productID', 'Product ID', isset($details['productID']) ? $details['productID'] : '');
+    echo $Form->text_field('pharmacy_productID', 'Pharmacy Product ID', isset($details['pharmacy_productID']) ? $details['pharmacy_productID'] : '');
+    echo $Form->text_field('pharmacy_name', 'Pharmacy Name', isset($details['pharmacy_name']) ? $details['pharmacy_name'] : '');
+    echo $Form->submit_field('btnSubmit', 'Save', $API->app_path());
+    echo $Form->form_end();
+?>

--- a/perch/addons/apps/perch_products_match_pharmacy/modes/mapping.edit.pre.php
+++ b/perch/addons/apps/perch_products_match_pharmacy/modes/mapping.edit.pre.php
@@ -1,0 +1,34 @@
+<?php
+    $Form = $API->get('Form');
+    $DB   = $API->get('DB');
+    $message = false;
+
+    $id = false;
+    if (PerchUtil::get('id')) {
+        $id = (int) PerchUtil::get('id');
+        $sql = 'SELECT * FROM '.PERCH_DB_PREFIX.'products_match_pharmacy WHERE id='.$DB->pdb($id).' LIMIT 1';
+        $details = $DB->get_row($sql);
+    } else {
+        $details = ['productID'=>'','pharmacy_productID'=>'','pharmacy_name'=>''];
+    }
+
+    if ($Form->submitted()) {
+        $postvars = ['productID','pharmacy_productID','pharmacy_name'];
+        $data = $Form->receive($postvars);
+
+        if ($id) {
+            $sql = 'UPDATE '.PERCH_DB_PREFIX.'products_match_pharmacy SET productID='.$DB->pdb((int)$data['productID']).', pharmacy_productID='.$DB->pdb($data['pharmacy_productID']).', pharmacy_name='.$DB->pdb($data['pharmacy_name']).' WHERE id='.$DB->pdb($id).' LIMIT 1';
+            $DB->execute($sql);
+            $message = $HTML->success_message('Mapping updated.');
+        } else {
+            $sql = 'INSERT INTO '.PERCH_DB_PREFIX.'products_match_pharmacy(productID, pharmacy_productID, pharmacy_name) VALUES ('.$DB->pdb((int)$data['productID']).','.$DB->pdb($data['pharmacy_productID']).','.$DB->pdb($data['pharmacy_name']).')';
+            $DB->execute($sql);
+            $id = $DB->insert_id();
+            PerchUtil::redirect($API->app_path().'/index.php?mode=mapping.edit&id='.$id.'&created=1');
+        }
+        $details = $data;
+    }
+
+    if (PerchUtil::get('created')) {
+        $message = $HTML->success_message('Mapping created.');
+    }

--- a/perch/addons/apps/perch_products_match_pharmacy/modes/mappings.list.post.php
+++ b/perch/addons/apps/perch_products_match_pharmacy/modes/mappings.list.post.php
@@ -1,0 +1,30 @@
+<?php
+    echo $HTML->title_panel([
+        'heading' => $Lang->get('Product Pharmacy Matches'),
+        'button'  => [
+            'text' => $Lang->get('Add match'),
+            'link' => $API->app_path() . '/index.php?mode=mapping.edit',
+            'icon' => 'core/plus'
+        ],
+    ], $CurrentUser);
+
+    if (PerchUtil::count($mappings)) {
+        echo '<table class="d">';
+        echo '<thead><tr><th>Product ID</th><th>Pharmacy Product ID</th><th>Pharmacy Name</th><th class="action"></th><th class="action"></th></tr></thead>';
+        echo '<tbody>';
+        foreach ($mappings as $item) {
+            $edit_link = $API->app_path() . '/index.php?mode=mapping.edit&id=' . $item['id'];
+            $del_link  = $API->app_path() . '/index.php?mode=mapping.delete&id=' . $item['id'];
+            echo '<tr>';
+            echo '<td>' . PerchUtil::html($item['productID']) . '</td>';
+            echo '<td>' . PerchUtil::html($item['pharmacy_productID']) . '</td>';
+            echo '<td>' . PerchUtil::html($item['pharmacy_name']) . '</td>';
+            echo '<td><a href="' . $edit_link . '" class="icon edit"></a></td>';
+            echo '<td><a href="' . $del_link . '" class="icon delete" onclick="return confirm(\'Delete mapping?\')"></a></td>';
+            echo '</tr>';
+        }
+        echo '</tbody></table>';
+    } else {
+        echo $HTML->warning_message('No mappings found.');
+    }
+?>

--- a/perch/addons/apps/perch_products_match_pharmacy/modes/mappings.list.pre.php
+++ b/perch/addons/apps/perch_products_match_pharmacy/modes/mappings.list.pre.php
@@ -1,0 +1,4 @@
+<?php
+    $DB = $API->get('DB');
+    $sql = 'SELECT * FROM '.PERCH_DB_PREFIX.'products_match_pharmacy ORDER BY id ASC';
+    $mappings = $DB->get_rows($sql);


### PR DESCRIPTION
## Summary
- Add `perch_products_match_pharmacy` admin app to manage product-to-pharmacy mappings.
- List, create, edit, and delete mappings between shop products and pharmacy products.

## Testing
- `php -l perch/addons/apps/perch_products_match_pharmacy/_default_index.php`
- `php -l perch/addons/apps/perch_products_match_pharmacy/index.php`
- `php -l perch/addons/apps/perch_products_match_pharmacy/modes/mappings.list.post.php`
- `php -l perch/addons/apps/perch_products_match_pharmacy/modes/mapping.delete.pre.php`
- `php -l perch/addons/apps/perch_products_match_pharmacy/modes/mappings.list.pre.php`
- `php -l perch/addons/apps/perch_products_match_pharmacy/modes/mapping.delete.post.php`
- `php -l perch/addons/apps/perch_products_match_pharmacy/modes/_subnav.php`
- `php -l perch/addons/apps/perch_products_match_pharmacy/modes/mapping.edit.post.php`
- `php -l perch/addons/apps/perch_products_match_pharmacy/modes/mapping.edit.pre.php`
- `php -l perch/addons/apps/perch_products_match_pharmacy/admin.php`


------
https://chatgpt.com/codex/tasks/task_b_68c005c328848324bd5f504197c361a5