### PR TITLE
Add product detail and variant API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,11 @@ Unread notifications display a red dot indicator and are marked as read when the
 To create a new notification in code, call `perch_member_add_notification($memberID, $title, $message)`.
 Administrators can also add notifications for a member from the member edit screen in the control panel.
 
+## Product API
+
+- `GET /api/products/{id}` returns the specified product with all of its variants.
+- `GET /api/products/{id}/variants` returns only the variants for that product.
+
+`{id}` corresponds to the product slug in Perch Shop.
 
 # perchDocumenttion

--- a/perch/addons/apps/api/index.php
+++ b/perch/addons/apps/api/index.php
@@ -4,13 +4,25 @@ header("Content-Type: application/json");
 $requestMethod = $_SERVER['REQUEST_METHOD'];
 $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 $path = str_replace("/api", "", $path);
-//echo "path".$path ;
+
 $routeFile = __DIR__ . "/routes{$path}.php";
-//echo $routeFile ;
+
+if (!file_exists($routeFile)) {
+    $segments = explode('/', trim($path, '/'));
+    if (count($segments) >= 2 && $segments[0] === 'products') {
+        $_GET['id'] = $segments[1];
+        if (isset($segments[2]) && $segments[2] === 'variants') {
+            $routeFile = __DIR__ . "/routes/product_variants.php";
+        } else {
+            $routeFile = __DIR__ . "/routes/product_single.php";
+        }
+    }
+}
+
 if (file_exists($routeFile)) {
 
     require $routeFile;
 } else {
-  //  http_response_code(404);
+    http_response_code(404);
     echo json_encode(["error" => "Endpoint not found"]);
 }

--- a/perch/addons/apps/api/routes/product_single.php
+++ b/perch/addons/apps/api/routes/product_single.php
@@ -1,0 +1,20 @@
+<?php
+include(__DIR__ .'/../../../../core/runtime/runtime.php');
+require_once __DIR__ . '/../auth.php';
+
+$id = $_GET['id'] ?? null;
+
+if (!$id) {
+    http_response_code(400);
+    echo json_encode(["error" => "Missing product ID"]);
+    exit;
+}
+
+$product = perch_shop_product($id, ['skip-template' => true, 'variants' => true]);
+
+if ($product) {
+    echo json_encode($product);
+} else {
+    http_response_code(404);
+    echo json_encode(["error" => "Product not found"]);
+}

--- a/perch/addons/apps/api/routes/product_variants.php
+++ b/perch/addons/apps/api/routes/product_variants.php
@@ -1,0 +1,20 @@
+<?php
+include(__DIR__ .'/../../../../core/runtime/runtime.php');
+require_once __DIR__ . '/../auth.php';
+
+$id = $_GET['id'] ?? null;
+
+if (!$id) {
+    http_response_code(400);
+    echo json_encode(["error" => "Missing product ID"]);
+    exit;
+}
+
+$variants = perch_shop_product_variants($id, ['skip-template' => true]);
+
+if ($variants) {
+    echo json_encode(['variants' => $variants]);
+} else {
+    http_response_code(404);
+    echo json_encode(["error" => "Product not found"]);
+}


### PR DESCRIPTION
## Summary
- add routing logic for dynamic product endpoints
- expose `/api/products/{id}` for product details with variants
- expose `/api/products/{id}/variants` for variant-only listings

## Testing
- `php -l perch/addons/apps/api/index.php`
- `php -l perch/addons/apps/api/routes/product_single.php`
- `php -l perch/addons/apps/api/routes/product_variants.php`


------
https://chatgpt.com/codex/tasks/task_b_68c2c826fa7c8324b4ec81cea2ee3818