### PR TITLE
Show package billing type on order list

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Orders.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Orders.class.php
@@ -209,11 +209,11 @@ $sort_val = null;
             $selectsql = 'SELECT';
         }
 
-        $selectsql .=  '  o.*, c.*, CONCAT(customerFirstName, " ", customerLastName) AS customerName ';
-         $fromsql =  '      FROM ' . $this->table .' o, '.PERCH_DB_PREFIX.'shop_customers c ';
+        $selectsql .=  '  o.*, c.*, pkg.billing_type, CONCAT(customerFirstName, " ", customerLastName) AS customerName ';
+         $fromsql =  '      FROM ' . $this->table .' o LEFT JOIN '.PERCH_DB_PREFIX.'shop_packages pkg ON pkg.orderID=o.orderID, '.PERCH_DB_PREFIX.'shop_customers c ';
                 $wheresql = ' WHERE o.customerID=c.customerID
-                             	AND o.orderDeleted IS NULL
-                             	AND o.orderStatus IN ("paid")';
+                                AND o.orderDeleted IS NULL
+                                AND o.orderStatus IN ("paid")';
                 	if($details["sendtopharmacy"]!=""){
                 	if($details["sendtopharmacy"]=="yes"){
                 	 // $selectsql .= ' ,p.* ';
@@ -271,11 +271,12 @@ $sql= $selectsql. $fromsql.$wheresql;
             $sql = 'SELECT';
         }
 
-        $sql .= ' o.*, c.*, CONCAT(customerFirstName, " ", customerLastName) AS customerName
-                FROM ' . $this->table .' o, '.PERCH_DB_PREFIX.'shop_customers c
-                WHERE o.customerID=c.customerID
-                	AND o.orderDeleted IS NULL 
-                	AND o.orderStatus IN ('.$this->db->implode_for_sql_in($status).')';
+        $sql .= ' o.*, c.*, pkg.billing_type, CONCAT(customerFirstName, " ", customerLastName) AS customerName
+                FROM ' . $this->table .' o
+                JOIN '.PERCH_DB_PREFIX.'shop_customers c ON o.customerID=c.customerID
+                LEFT JOIN '.PERCH_DB_PREFIX.'shop_packages pkg ON pkg.orderID=o.orderID
+                WHERE o.orderDeleted IS NULL
+                        AND o.orderStatus IN ('.$this->db->implode_for_sql_in($status).')';
 
 		if ($sort_val) {
             $sql .= ' ORDER BY '.$sort_val.' '.$sort_dir;

--- a/perch/addons/apps/perch_shop_orders/modes/orders.list.post.php
+++ b/perch/addons/apps/perch_shop_orders/modes/orders.list.post.php
@@ -54,6 +54,15 @@
             'value'     => 'statusTitle',
             'sort'      => 'orderStatus',
         ]);
+
+    $Listing->add_col([
+            'title'     => 'Package',
+            'value'     => function($Item) {
+                $type = $Item->billing_type();
+                return $type ? ucfirst($type) : '';
+            },
+            'sort'      => 'billing_type',
+        ]);
     
 
     $Listing->add_delete_action([


### PR DESCRIPTION
## Summary
- display billing type for package orders in admin order list
- pull package billing data via new join on orders queries

## Testing
- `php -l perch/addons/apps/perch_shop/lib/PerchShop_Orders.class.php`
- `php -l perch/addons/apps/perch_shop_orders/modes/orders.list.post.php`


------
https://chatgpt.com/codex/tasks/task_b_68c545c7e6408324b538407986f55c4e