### PR TITLE
Add logging to payment notification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ This outputs the date when the next payment is due.
 pending packages with a `nextBillingDate` one week in the future and uses
 Perch's email library to notify the associated customers.
 
+The script records each notification in `logs/send_payment_notification.log`.
+It creates the `logs` directory if needed and ensures it is writable,
+skipping sending duplicates if an entry already exists.
+
 Run the script from the command line:
 
 ```

--- a/send_payment_notification.php
+++ b/send_payment_notification.php
@@ -9,25 +9,50 @@ $table  = PERCH_DB_PREFIX . 'shop_packages';
 $tableitems  = PERCH_DB_PREFIX . 'shop_package_items';
 $target = (new DateTimeImmutable('+1 week'))->format('Y-m-d');
 
+$log_dir  = __DIR__ . '/logs';
+if (!is_dir($log_dir)) {
+    mkdir($log_dir, 0777, true);
+}
+if (!is_writable($log_dir)) {
+    chmod($log_dir, 0777);
+}
+$log_file = $log_dir . '/send_payment_notification.log';
+$sent     = [];
+if (file_exists($log_file)) {
+    foreach (file($log_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+        $parts = explode('|', $line);
+        if (count($parts) >= 2) {
+            $sent[$parts[0] . '|' . $parts[1]] = true;
+        }
+    }
+}
+
 $sql = 'SELECT p.customerID, i.billingDate FROM ' . $tableitems .
        ' as i inner join   ' . $table . ' as p WHERE i.packageID=p.uuid and  p.billing_type="monthly" and i.paymentStatus=' . $DB->pdb('pending') .
        ' AND i.billingDate=' . $DB->pdb($target);
-echo $sql;
 $packages = $DB->get_rows($sql);
 
 if (PerchUtil::count($packages)) {
     foreach ($packages as $package) {
-    echo "package";print_r($package);
+        $key = $package['customerID'] . '|' . $package['billingDate'];
+        if (isset($sent[$key])) {
+            file_put_contents(
+                $log_file,
+                $key . '|' . date('c') . "|skipped\n",
+                FILE_APPEND | LOCK_EX
+            );
+            continue;
+        }
+
         $Customer = $Customers->find((int)$package['customerID']);
         if (!$Customer) {
             continue;
-
         }
-        $memberID=$Customer->memberID();
-        $title='Upcoming Payment Reminder';
-        $message='Your next payment is due on ' . $package['billingDate'] . '. Please complete it from your portal.';
+        $memberID = $Customer->memberID();
+        $title    = 'Upcoming Payment Reminder';
+        $message  = 'Your next payment is due on ' . $package['billingDate'] . '. Please complete it from your portal.';
 
- perch_member_add_notification($memberID, $title, $message);
+        perch_member_add_notification($memberID, $title, $message);
         $Email = new PerchEmail('');
         $Email->subject('Upcoming Payment Reminder');
         $Email->senderName('Weightloss');
@@ -36,6 +61,12 @@ if (PerchUtil::count($packages)) {
         $Email->body('Your next payment is due on ' . $package['billingDate'] . '. Please complete it from your portal.');
 
         $Email->send();
+        file_put_contents(
+            $log_file,
+            $key . '|' . date('c') . "|sent\n",
+            FILE_APPEND | LOCK_EX
+        );
+        $sent[$key] = true;
     }
 }
 


### PR DESCRIPTION
## Summary
- create logs directory for `send_payment_notification.php`
- ensure log directory is writable before recording entries
- document logs directory usage in README

## Testing
- `php -l send_payment_notification.php`


------
https://chatgpt.com/codex/tasks/task_b_68c5688a4e0c8324ad55568b3e836cd7