### PR TITLE
feat: add notification logs admin module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Perch's email library to notify the associated customers.
 
 The script records each notification in `logs/send_payment_notification.log`.
 It creates the `logs` directory if needed and ensures it is writable,
-skipping sending duplicates if an entry already exists.
+skipping sending duplicates if an entry already exists. Administrators can
+review these entries from the **Notification Logs** module in the admin area
+(`perch/addons/apps/perch_notification_logs/index.php`).
 
 
 Run the script from the command line:

--- a/perch/addons/apps/perch_notification_logs/_default_index.php
+++ b/perch/addons/apps/perch_notification_logs/_default_index.php
@@ -1,0 +1,17 @@
+<?php
+# include the API
+include(__DIR__.'/../../../core/inc/api.php');
+
+$API  = new PerchAPI(1.0, 'perch_notification_logs');
+$Lang = $API->get('Lang');
+$HTML = $API->get('HTML');
+
+$Perch->page_title = $Lang->get($title);
+
+include('modes/'.$mode.'.pre.php');
+
+include(PERCH_CORE . '/inc/top.php');
+
+include('modes/'.$mode.'.post.php');
+
+include(PERCH_CORE . '/inc/btm.php');

--- a/perch/addons/apps/perch_notification_logs/admin.php
+++ b/perch/addons/apps/perch_notification_logs/admin.php
@@ -1,0 +1,4 @@
+<?php
+if ($CurrentUser->logged_in() && $CurrentUser->has_priv('perch_notification_logs')) {
+    $this->register_app('perch_notification_logs', 'Notification Logs', 1, 'View notification log entries', '1.0');
+}

--- a/perch/addons/apps/perch_notification_logs/index.php
+++ b/perch/addons/apps/perch_notification_logs/index.php
@@ -1,0 +1,5 @@
+<?php
+$mode  = 'logs';
+$title = 'Notification Logs';
+
+include '_default_index.php';

--- a/perch/addons/apps/perch_notification_logs/modes/logs.post.php
+++ b/perch/addons/apps/perch_notification_logs/modes/logs.post.php
@@ -1,0 +1,27 @@
+<?php if (!empty($logs)): ?>
+    <?php foreach ($logs as $filename => $entries): ?>
+        <h2><?php echo $HTML->encode($filename); ?></h2>
+        <table class="d">
+            <thead>
+                <tr>
+                    <th><?php echo $Lang->get('Customer ID'); ?></th>
+                    <th><?php echo $Lang->get('Billing Date'); ?></th>
+                    <th><?php echo $Lang->get('Logged At'); ?></th>
+                    <th><?php echo $Lang->get('Status'); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($entries as $entry): ?>
+                <tr>
+                    <td><?php echo $HTML->encode($entry['customerID']); ?></td>
+                    <td><?php echo $HTML->encode($entry['billingDate']); ?></td>
+                    <td><?php echo $HTML->encode($entry['loggedAt']); ?></td>
+                    <td><?php echo $HTML->encode($entry['status']); ?></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    <?php endforeach; ?>
+<?php else: ?>
+    <p><?php echo $Lang->get('No notification logs found.'); ?></p>
+<?php endif; ?>

--- a/perch/addons/apps/perch_notification_logs/modes/logs.pre.php
+++ b/perch/addons/apps/perch_notification_logs/modes/logs.pre.php
@@ -1,0 +1,22 @@
+<?php
+$log_dir = realpath(__DIR__.'/../../../../logs');
+$logs = [];
+if ($log_dir && is_dir($log_dir)) {
+    $files = glob($log_dir . '/send_payment_notification*.log');
+    sort($files);
+    foreach ($files as $file) {
+        $entries = [];
+        foreach (file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+            $parts = explode('|', $line);
+            if (count($parts) >= 3) {
+                $entries[] = [
+                    'customerID' => $parts[0],
+                    'billingDate' => $parts[1],
+                    'loggedAt' => $parts[2],
+                    'status' => $parts[3] ?? ''
+                ];
+            }
+        }
+        $logs[basename($file)] = $entries;
+    }
+}


### PR DESCRIPTION
## Summary
- move notification log viewer into its own admin module
- document new Notification Logs module location

## Testing
- `php -l perch/addons/apps/perch_notification_logs/admin.php`
- `php -l perch/addons/apps/perch_notification_logs/_default_index.php`
- `php -l perch/addons/apps/perch_notification_logs/index.php`
- `php -l perch/addons/apps/perch_notification_logs/modes/logs.pre.php`
- `php -l perch/addons/apps/perch_notification_logs/modes/logs.post.php`


------
https://chatgpt.com/codex/tasks/task_b_68c56c621eb083249513b6723afc9b69