### PR TITLE
Adjust post-impersonation redirect

### DIFF
--- a/perch/addons/apps/perch_members/modes/members.impersonate.pre.php
+++ b/perch/addons/apps/perch_members/modes/members.impersonate.pre.php
@@ -34,16 +34,12 @@
         $log_line = sprintf('[%s] Admin %d impersonated member %d'."\n", date('Y-m-d H:i:s'), $CurrentUser->id(), $Member->id());
         $log_file = PERCH_PATH.'/addons/apps/perch_members/impersonate.log';
         file_put_contents($log_file, $log_line, FILE_APPEND);
-
-         PerchUtil::redirect('/client');
-        // After impersonating, redirect to the package builder
-       // $site = PerchRequest::get('site');
-        if(isset( PerchRequest::get('site'))){
-                PerchUtil::redirect('/order/package-builder');
-
-        }else{
-
-         PerchUtil::redirect('/client');
+        // After impersonating, redirect to the appropriate page
+        $site = PerchRequest::get('site');
+        if ($site) {
+            PerchUtil::redirect('/order/package-builder');
+        } else {
+            PerchUtil::redirect('/client');
         }
     }
 


### PR DESCRIPTION
## Summary
- redirect to package builder when `site` parameter is present
- default back to client portal if no `site` parameter

## Testing
- `php -l perch/addons/apps/perch_members/modes/members.impersonate.pre.php`

------
https://chatgpt.com/codex/tasks/task_b_68c81d187bbc8324bb9511f889618712