### PR TITLE
Track payment reminder notifications per package item

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ This outputs the date when the next payment is due.
 pending packages with a `nextBillingDate` one week in the future and uses
 Perch's email library to notify the associated customers.
 
-The script records each notification in `logs/send_payment_notification.log`.
-It creates the `logs` directory if needed and ensures it is writable,
-skipping sending duplicates if an entry already exists. Administrators can
+The script records each notification in `logs/notifications/send_payment_notificationYYYY-MM-DD.log`.
+Entries are keyed by the package item ID, so the same item isn't notified
+twice. It creates the `logs` directory if needed and ensures it is writable.
+Administrators can
 review these entries from the **Notification Logs** module in the admin area
 (`perch/addons/apps/perch_notification_logs/index.php`).
 

--- a/perch/addons/apps/perch_notification_logs/modes/logs.post.php
+++ b/perch/addons/apps/perch_notification_logs/modes/logs.post.php
@@ -4,6 +4,7 @@
         <table class="d">
             <thead>
                 <tr>
+                    <th><?php echo $Lang->get('Item ID'); ?></th>
                     <th><?php echo $Lang->get('Customer ID'); ?></th>
                     <th><?php echo $Lang->get('Billing Date'); ?></th>
                     <th><?php echo $Lang->get('Logged At'); ?></th>
@@ -13,10 +14,11 @@
             <tbody>
             <?php foreach ($entries as $entry): ?>
                 <tr>
-                    <td><?php echo $HTML->encode($entry['customerID']); ?></td>
-                    <td><?php echo $HTML->encode($entry['billingDate']); ?></td>
-                    <td><?php echo $HTML->encode($entry['loggedAt']); ?></td>
-                    <td><?php echo $HTML->encode($entry['status']); ?></td>
+                    <td><?php echo $HTML->encode($entry['itemID'] ?? ''); ?></td>
+                    <td><?php echo $HTML->encode($entry['customerID'] ?? ''); ?></td>
+                    <td><?php echo $HTML->encode($entry['billingDate'] ?? ''); ?></td>
+                    <td><?php echo $HTML->encode($entry['loggedAt'] ?? ''); ?></td>
+                    <td><?php echo $HTML->encode($entry['status'] ?? ''); ?></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>

--- a/perch/addons/apps/perch_notification_logs/modes/logs.pre.php
+++ b/perch/addons/apps/perch_notification_logs/modes/logs.pre.php
@@ -10,8 +10,17 @@ if ($log_dir && is_dir($log_dir)) {
         $entries = [];
         foreach (file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
             $parts = explode('|', $line);
-            if (count($parts) >= 3) {
+            if (count($parts) >= 5) {
                 $entries[] = [
+                    'itemID' => $parts[0],
+                    'customerID' => $parts[1],
+                    'billingDate' => $parts[2],
+                    'loggedAt' => $parts[3],
+                    'status' => $parts[4] ?? ''
+                ];
+            } elseif (count($parts) >= 3) {
+                $entries[] = [
+                    'itemID' => '',
                     'customerID' => $parts[0],
                     'billingDate' => $parts[1],
                     'loggedAt' => $parts[2],

--- a/send_payment_notification.php
+++ b/send_payment_notification.php
@@ -16,42 +16,54 @@ if (!is_dir($log_dir)) {
 if (!is_writable($log_dir)) {
     chmod($log_dir, 0777);
 }
-$log_file = $log_dir . '/send_payment_notification'.$target.'.log';
+$log_file = $log_dir . '/send_payment_notification' . $target . '.log';
 
-$sent     = [];
+$sent = [];
 if (file_exists($log_file)) {
     foreach (file($log_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
         $parts = explode('|', $line);
-        if (count($parts) >= 2) {
-            $sent[$parts[0] . '|' . $parts[1]] = true;
+        if (count($parts) >= 5) {
+            $sent['item:' . $parts[0]] = true;
+        } elseif (count($parts) >= 2) {
+            $sent['legacy:' . $parts[0] . '|' . $parts[1]] = true;
         }
     }
 }
 
-$sql = 'SELECT p.customerID, i.billingDate FROM ' . $tableitems .
+$writeLog = function ($itemID, $customerID, $billingDate, $status) use ($log_file) {
+    $line = $itemID . '|' . $customerID . '|' . $billingDate . '|' . date('c') . '|' . $status . "\n";
+    file_put_contents($log_file, $line, FILE_APPEND | LOCK_EX);
+};
+
+$sql = 'SELECT p.customerID, i.billingDate, i.itemID FROM ' . $tableitems .
        ' as i inner join   ' . $table . ' as p WHERE i.packageID=p.uuid and  p.billing_type="monthly" and i.paymentStatus=' . $DB->pdb('pending') .
        ' AND i.billingDate=' . $DB->pdb($target);
 $packages = $DB->get_rows($sql);
 
 if (PerchUtil::count($packages)) {
     foreach ($packages as $package) {
-        $key = $package['customerID'] . '|' . $package['billingDate'];
-        if (isset($sent[$key])) {
-            file_put_contents(
-                $log_file,
-                $key . '|' . date('c') . "|skipped\n",
-                FILE_APPEND | LOCK_EX
-            );
+        $itemID = isset($package['itemID']) ? (int) $package['itemID'] : 0;
+        $customerID = $package['customerID'] ?? '';
+        $billingDate = $package['billingDate'] ?? '';
+        $itemKey = 'item:' . $itemID;
+        $legacyKey = 'legacy:' . $customerID . '|' . $billingDate;
+
+        if (($itemID && isset($sent[$itemKey])) || isset($sent[$legacyKey])) {
+            $writeLog($itemID, $customerID, $billingDate, 'skipped');
+            $sent[$itemKey] = true;
+            if (isset($sent[$legacyKey])) {
+                unset($sent[$legacyKey]);
+            }
             continue;
         }
 
-        $Customer = $Customers->find((int)$package['customerID']);
+        $Customer = $Customers->find((int) $customerID);
         if (!$Customer) {
             continue;
         }
         $memberID = $Customer->memberID();
         $title    = 'Upcoming Payment Reminder';
-        $message  = 'Your next payment is due on ' . $package['billingDate'] . '. Please complete it from your portal.';
+        $message  = 'Your next payment is due on ' . $billingDate . '. Please complete it from your portal.';
 
         perch_member_add_notification($memberID, $title, $message);
         $Email = new PerchEmail('');
@@ -59,15 +71,11 @@ if (PerchUtil::count($packages)) {
         $Email->senderName('Weightloss');
         $Email->senderEmail('no-reply@example.com');
         $Email->recipientEmail($Customer->customerEmail());
-        $Email->body('Your next payment is due on ' . $package['billingDate'] . '. Please complete it from your portal.');
+        $Email->body('Your next payment is due on ' . $billingDate . '. Please complete it from your portal.');
 
         $Email->send();
-        file_put_contents(
-            $log_file,
-            $key . '|' . date('c') . "|sent\n",
-            FILE_APPEND | LOCK_EX
-        );
-        $sent[$key] = true;
+        $writeLog($itemID, $customerID, $billingDate, 'sent');
+        $sent[$itemKey] = true;
     }
 }
 


### PR DESCRIPTION
## Summary
- update the payment notification script to track log entries by package item and skip duplicates on reruns
- extend the notification log viewer to display item IDs while remaining compatible with legacy log files
- document the new per-item log behaviour for payment reminders

## Testing
- php -l send_payment_notification.php
- php -l perch/addons/apps/perch_notification_logs/modes/logs.pre.php
- php -l perch/addons/apps/perch_notification_logs/modes/logs.post.php

------
https://chatgpt.com/codex/tasks/task_b_68c96ec05e988324810abe594c0bedd1