### PR TITLE
Add editable status dropdown to package view

### DIFF
--- a/perch/addons/apps/perch_shop_orders/modes/package.edit.post.php
+++ b/perch/addons/apps/perch_shop_orders/modes/package.edit.post.php
@@ -12,6 +12,16 @@
 
 
 
+    $form_action = $HTML->encode($Form->action());
+    $csrf_token  = $HTML->encode(PerchSession::get('csrf_token'));
+
+    if (!isset($status_choices) || !is_array($status_choices)) {
+        $status_choices = ['confirmed', 'completed', 'cancelled'];
+    }
+
+    $current_status = trim((string)$Package->status());
+
+
 
 $output= $HTML->heading2('Package');
 
@@ -34,6 +44,24 @@ $output= $HTML->heading2('Package');
     $output.=  '<tr>';
         $output.=  '<th>'.$Lang->get('PaymentStatus').'</th>';
         $output.=  '<td>'.$HTML->encode(ucfirst($Package->paymentStatus())).'</td>';
+    $output.=  '</tr>';
+
+    $output.=  '<tr>';
+        $output.=  '<th>'.$Lang->get('Status').'</th>';
+        $output.=  '<td>';
+            $output.=  '<form method="post" action="'.$form_action.'" class="inline-package-status">';
+            $output.=  '<input type="hidden" name="formaction" value="update_status">';
+            $output.=  '<input type="hidden" name="token" value="'.$csrf_token.'">';
+            $output.=  '<select name="status">';
+            foreach ($status_choices as $status_option) {
+                $label = $Lang->get(ucfirst($status_option));
+                $selected = ($status_option === $current_status) ? ' selected="selected"' : '';
+                $output.=  '<option value="'.$HTML->encode($status_option).'"'.$selected.'>'.$HTML->encode($label).'</option>';
+            }
+            $output.=  '</select>';
+            $output.=  '<button type="submit" class="button button-simple button-small">'.$HTML->encode($Lang->get('Save')).'</button>';
+            $output.=  '</form>';
+        $output.=  '</td>';
     $output.=  '</tr>';
 
     $output.=  '<tr>';
@@ -106,9 +134,6 @@ $output.=  $HTML->heading2('Customer');
                 $output.=  '<th>'.$Lang->get('orderID').'</th>';
         $output.=  '</tr>';
         $output.=  '</thead>';
-
-        $form_action = $HTML->encode($Form->action());
-        $csrf_token  = $HTML->encode(PerchSession::get('csrf_token'));
 
         foreach($items as $Item) {
             #PerchUtil::debug($Item);

--- a/perch/addons/apps/perch_shop_orders/modes/package.edit.pre.php
+++ b/perch/addons/apps/perch_shop_orders/modes/package.edit.pre.php
@@ -25,6 +25,36 @@
 
                 $Customer    = $Customers->find($Package->customerID());
 
+                if (!PerchSession::get('csrf_token')) {
+                    PerchSession::set('csrf_token', md5(uniqid('csrf', true)));
+                }
+
+                $status_choices = ['confirmed', 'completed', 'cancelled'];
+
+                if (PerchUtil::post('formaction') === 'update_status') {
+                    $token          = PerchUtil::post('token');
+                    $session_token  = PerchSession::get('csrf_token');
+
+                    if (!$token || !$session_token || $token !== $session_token) {
+                        $message = $HTML->failure_message($Lang->get('Sorry, that request could not be authorised. Please try again.'));
+                        PerchSession::set('csrf_token', md5(uniqid('csrf', true)));
+                    } else {
+                        PerchSession::set('csrf_token', md5(uniqid('csrf', true)));
+
+                        $status = trim((string)PerchUtil::post('status'));
+
+                        if (in_array($status, $status_choices, true)) {
+                            if ($Package->update(['status' => $status])) {
+                                $message = $HTML->success_message($Lang->get('Package status updated successfully.'));
+                            } else {
+                                $message = $HTML->failure_message($Lang->get('Sorry, that update was not successful.'));
+                            }
+                        } else {
+                            $message = $HTML->failure_message($Lang->get('Please select a valid status.'));
+                        }
+                    }
+                }
+
                 if (PerchUtil::post('formaction') === 'update_billing_date') {
                     $token          = PerchUtil::post('token');
                     $session_token  = PerchSession::get('csrf_token');


### PR DESCRIPTION
## Summary
- initialize CSRF token and handle package status updates in the edit controller
- expose a status dropdown with confirmed/completed/cancelled options on the package detail view

## Testing
- php -l perch/addons/apps/perch_shop_orders/modes/package.edit.pre.php
- php -l perch/addons/apps/perch_shop_orders/modes/package.edit.post.php

------
https://chatgpt.com/codex/tasks/task_b_68ca86a73a688324a4eab4bd9869b767