### PR TITLE
Fix parse error in package billing date update logic

### DIFF
--- a/perch/addons/apps/perch_shop_orders/modes/package.edit.pre.php
+++ b/perch/addons/apps/perch_shop_orders/modes/package.edit.pre.php
@@ -78,7 +78,6 @@
 
                                 if ($Item && $Item->packageID() == $Package->uuid()) {
                                     if ((int)$Item->month() === 1) {
-
                                         $update_success = $Item->update(['billingDate' => $billingDate]);
 
                                         if ($update_success) {
@@ -108,9 +107,6 @@
                                         }
 
                                         if ($update_success) {
-
-                                        if ($Item->update(['billingDate' => $billingDate])) {
-
                                             $message = $HTML->success_message($Lang->get('Billing date updated successfully.'));
                                         } else {
                                             $message = $HTML->failure_message($Lang->get('Sorry, that update was not successful.'));


### PR DESCRIPTION
## Summary
- remove the redundant nested `if ($Item->update(...))` block that left braces unbalanced
- rely on `$update_success` to report the billing date update result after propagating dates to the remaining items

## Testing
- php -l perch/addons/apps/perch_shop_orders/modes/package.edit.pre.php

------
https://chatgpt.com/codex/tasks/task_b_68ca98fd50c483249261bdcce6488682