### PR TITLE
Add admin package filters for status, payment state, and date

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Packages.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Packages.class.php
@@ -35,9 +35,106 @@ class PerchShop_Packages extends PerchShop_Factory
         return $this->return_instances($this->db->get_rows($sql));
     }
 
-    	public function get_admin_listing($status=array('paid'), $Paging=false)
-    	{
-    		$sort_val = null;
+    public function get_by_properties($details, $Paging=false)
+    {
+        $sort_val = null;
+        $sort_dir = null;
+
+        if ($Paging && $Paging->enabled()) {
+            $selectsql = $Paging->select_sql();
+            list($sort_val, $sort_dir) = $Paging->get_custom_sort_options();
+        }else{
+            $selectsql = 'SELECT';
+        }
+
+        $selectsql .= ' p.*, c.*, CONCAT(customerFirstName, " ", customerLastName) AS customerName'
+                    . ' FROM ' . $this->table .' p, '.PERCH_DB_PREFIX.'shop_customers c';
+
+        $wheresql = ' WHERE p.customerID=c.customerID';
+
+        $default_payment_statuses = ['pending', 'paid'];
+
+        $payment_status = '';
+        if (isset($details['paymentStatus'])) {
+            $payment_status = trim((string)$details['paymentStatus']);
+        }
+
+        if ($payment_status !== '') {
+            $wheresql .= ' AND p.paymentStatus=' . $this->db->pdb($payment_status);
+        }else{
+            $wheresql .= ' AND p.paymentStatus IN (' . $this->db->implode_for_sql_in($default_payment_statuses) . ')';
+        }
+
+        if (isset($details['status'])) {
+            $status = trim((string)$details['status']);
+            if ($status !== '') {
+                $wheresql .= ' AND p.status=' . $this->db->pdb($status);
+            }
+        }
+
+        $from = null;
+        if (isset($details['fromdate'])) {
+            $fromdate = trim((string)$details['fromdate']);
+            if ($fromdate !== '') {
+                $from_dt = \DateTime::createFromFormat('Y-m-d', $fromdate);
+                if ($from_dt instanceof \DateTime) {
+                    $from_dt->setTime(0, 0, 0);
+                    $from = $from_dt->format('Y-m-d H:i:s');
+                }
+            }
+        }
+
+        $to = null;
+        if (isset($details['todate'])) {
+            $todate = trim((string)$details['todate']);
+            if ($todate !== '') {
+                $to_dt = \DateTime::createFromFormat('Y-m-d', $todate);
+                if ($to_dt instanceof \DateTime) {
+                    $to_dt->setTime(23, 59, 59);
+                    $to = $to_dt->format('Y-m-d H:i:s');
+                }
+            }
+        }
+
+        if ($from && $to) {
+            if (strtotime($from) > strtotime($to)) {
+                $tmp = $from;
+                $from = $to;
+                $to = $tmp;
+            }
+            $wheresql .= ' AND p.created BETWEEN ' . $this->db->pdb($from) . ' AND ' . $this->db->pdb($to);
+        }elseif ($from) {
+            $wheresql .= ' AND p.created >= ' . $this->db->pdb($from);
+        }elseif ($to) {
+            $wheresql .= ' AND p.created <= ' . $this->db->pdb($to);
+        }
+
+        $sql = $selectsql . $wheresql;
+
+        if ($sort_val) {
+            $sql .= ' ORDER BY '.$sort_val.' '.$sort_dir;
+        } else {
+            if (isset($this->default_sort_column)) {
+                $sql .= ' ORDER BY p.created DESC ';
+            }
+        }
+
+        if ($Paging && $Paging->enabled()) {
+            $sql .=  ' '.$Paging->limit_sql();
+        }
+
+        $results = $this->db->get_rows($sql);
+
+        if ($Paging && $Paging->enabled()) {
+            $Paging->set_total($this->db->get_count($Paging->total_count_sql()));
+        }
+
+        return $this->return_instances($results);
+    }
+
+        public function get_admin_listing($status=array('paid'), $Paging=false)
+        {
+                $sort_val = null;
             $sort_dir = null;
 
 

--- a/perch/addons/apps/perch_shop/templates/shop/orders/packages_filter.html
+++ b/perch/addons/apps/perch_shop/templates/shop/orders/packages_filter.html
@@ -1,0 +1,4 @@
+<perch:shop type="select" id="status" label="Status" options="All statuses|,Confirmed|confirmed,Completed|completed,Cancelled|cancelled" />
+<perch:shop type="select" id="paymentStatus" label="Payment status" options="All payment statuses|,Pending|pending,Paid|paid,Cancelled|cancelled" />
+<perch:shop type="date" id="fromdate" label="From date" />
+<perch:shop type="date" id="todate" label="To date" />

--- a/perch/addons/apps/perch_shop_orders/modes/packages.list.post.php
+++ b/perch/addons/apps/perch_shop_orders/modes/packages.list.post.php
@@ -15,7 +15,15 @@
 
     include('_orders_smartbar.php');
        
-	/* ----------------------------------------- /SMART BAR ----------------------------------------- */
+        /* ----------------------------------------- /SMART BAR ----------------------------------------- */
+
+
+    echo $Form->form_start(false, 'packages-filter');
+        echo $Form->fields_from_template($Template, $details, array(), false);
+
+        echo $Form->submit_field('btnSubmit', 'Search', $API->app_path());
+
+        echo $Form->form_end();
 
 
     $Listing = new PerchAdminListing($CurrentUser, $HTML, $Lang, $Paging);

--- a/perch/addons/apps/perch_shop_orders/modes/packages.list.pre.php
+++ b/perch/addons/apps/perch_shop_orders/modes/packages.list.pre.php
@@ -6,7 +6,7 @@ $sort="^orderCreated";
 	$PackageItems = new PerchShop_PackageItems($API);
 
     $Template   = $API->get('Template');
-    $Template->set('shop/orders/filter.html', 'shop');
+    $Template->set('shop/orders/packages_filter.html', 'shop');
 
     $Form = $API->get('Form');
     $Form->handle_empty_block_generation($Template);
@@ -16,12 +16,16 @@ $sort="^orderCreated";
 
                    $post = $_POST;
 
-                   $data = $Form->get_posted_content($Template, $Orders, false, false);
-                   $filerdata= json_encode($data);
-                 // print_r( $filerdata);
+                   $data = $Form->get_posted_content($Template, $Packages, false, false);
 
-                    $details=$data["orderDynamicFields"];
-                $details =json_decode($details, TRUE);
+                    $details_json = $data["packageDynamicFields"] ?? '[]';
+                if (!is_string($details_json)) {
+                    $details_json = json_encode($details_json);
+                }
+                $details = json_decode($details_json, TRUE);
+                if (!is_array($details)) {
+                    $details = [];
+                }
  $packages = $Packages->get_by_properties($details, $Paging);
 
 


### PR DESCRIPTION
## Summary
- add a dedicated package filter template with status, payment status, and date inputs
- update the packages list controller to parse the new filter form and load filtered results
- expose a `get_by_properties` helper on packages to support filtering logic and render the filter form in the list view

## Testing
- php -l perch/addons/apps/perch_shop_orders/modes/packages.list.pre.php
- php -l perch/addons/apps/perch_shop_orders/modes/packages.list.post.php
- php -l perch/addons/apps/perch_shop/lib/PerchShop_Packages.class.php

------
https://chatgpt.com/codex/tasks/task_b_68caaf1ba4948324bb5e126a32e4b613