### PR TITLE
Align future billing dates after first payment

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_PackageItem.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_PackageItem.class.php
@@ -9,10 +9,100 @@ class PerchShop_PackageItem extends PerchShop_Base
 
     protected $event_prefix = 'shop.packageitem';
 
-     public function set_status_paid($orderID){
+    public function set_status_paid($orderID)
+    {
+        $result = $this->update([
+            'orderID' => $orderID,
+            'paymentStatus' => 'paid',
+        ]);
 
-        $this->update(['orderID'=>$orderID,  'paymentStatus' => 'paid'
-                                                         ]);
-     }
+        if ($result === false) {
+            return false;
+        }
+
+        if ((int)$this->month() !== 1) {
+            return true;
+        }
+
+        $payment_date = $this->resolve_payment_date($orderID);
+
+        $Items = new PerchShop_PackageItems($this->api);
+        $package_items = $Items->get_for_package($this->packageID());
+
+        if (!PerchUtil::count($package_items)) {
+            return true;
+        }
+
+        $all_updated = true;
+        $next_billing_date = null;
+
+        foreach ($package_items as $PackageItem) {
+            if ((int)$PackageItem->itemID() === (int)$this->itemID()) {
+                continue;
+            }
+
+            $month_number = (int)$PackageItem->month();
+            if ($month_number <= 1) {
+                continue;
+            }
+
+            $target_date = $payment_date->modify('+' . ($month_number - 1) . ' month');
+            $formatted   = $target_date->format('Y-m-d');
+
+            if ($PackageItem->billingDate() !== $formatted) {
+                if ($PackageItem->update(['billingDate' => $formatted]) === false) {
+                    $all_updated = false;
+                }
+            }
+
+            $status = strtolower((string)$PackageItem->paymentStatus());
+            if ($status !== 'paid') {
+                if ($next_billing_date === null || $formatted < $next_billing_date) {
+                    $next_billing_date = $formatted;
+                }
+            }
+        }
+
+        if ($next_billing_date !== null) {
+            $Packages = new PerchShop_Packages($this->api);
+            $Package  = $Packages->find_by_uuid($this->packageID());
+
+            if ($Package) {
+                if ($Package->update(['nextBillingDate' => $next_billing_date]) === false) {
+                    $all_updated = false;
+                }
+            }
+        }
+
+        return $all_updated;
+    }
+
+    private function resolve_payment_date($orderID)
+    {
+        if ($orderID) {
+            $Orders = new PerchShop_Orders($this->api);
+            $Order  = $Orders->find((int)$orderID);
+
+            if ($Order) {
+                $raw_date = $Order->orderCreated();
+
+                if ($raw_date) {
+                    $date = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $raw_date);
+
+                    if ($date instanceof \DateTimeImmutable) {
+                        return $date;
+                    }
+
+                    try {
+                        return new \DateTimeImmutable($raw_date);
+                    } catch (\Exception $e) {
+                        // fall back to current date below
+                    }
+                }
+            }
+        }
+
+        return new \DateTimeImmutable('today');
+    }
 }
 


### PR DESCRIPTION
## Summary
- update PerchShop_PackageItem::set_status_paid to cascade new billing dates when month-one payments are recorded
- calculate future billing dates from the actual payment date and refresh the package nextBillingDate
- extend PerchShop_Package::set_status to reschedule package items and nextBillingDate after the first payment is logged

## Testing
- php -l perch/addons/apps/perch_shop/lib/PerchShop_PackageItem.class.php
- php -l perch/addons/apps/perch_shop/lib/PerchShop_Package.class.php

------
https://chatgpt.com/codex/tasks/task_b_68cab7f87c208324910c6e0c606a00d9