### PR TITLE
Link notification log rows to package notifications

### DIFF
--- a/perch/addons/apps/perch_notification_logs/modes/logs.post.php
+++ b/perch/addons/apps/perch_notification_logs/modes/logs.post.php
@@ -9,16 +9,55 @@
                     <th><?php echo $Lang->get('Billing Date'); ?></th>
                     <th><?php echo $Lang->get('Logged At'); ?></th>
                     <th><?php echo $Lang->get('Status'); ?></th>
+                    <th><?php echo $Lang->get('Send Notification Page'); ?></th>
                 </tr>
             </thead>
             <tbody>
             <?php foreach ($entries as $entry): ?>
+                <?php $link = $entry['link'] ?? null; ?>
                 <tr>
-                    <td><?php echo $HTML->encode($entry['itemID'] ?? ''); ?></td>
-                    <td><?php echo $HTML->encode($entry['customerID'] ?? ''); ?></td>
-                    <td><?php echo $HTML->encode($entry['billingDate'] ?? ''); ?></td>
-                    <td><?php echo $HTML->encode($entry['loggedAt'] ?? ''); ?></td>
-                    <td><?php echo $HTML->encode($entry['status'] ?? ''); ?></td>
+                    <td>
+                        <?php if ($link): ?>
+                            <a href="<?php echo $HTML->encode($link); ?>"><?php echo $HTML->encode($entry['itemID'] ?? ''); ?></a>
+                        <?php else: ?>
+                            <?php echo $HTML->encode($entry['itemID'] ?? ''); ?>
+                        <?php endif; ?>
+                    </td>
+                    <td>
+                        <?php if ($link): ?>
+                            <a href="<?php echo $HTML->encode($link); ?>"><?php echo $HTML->encode($entry['customerID'] ?? ''); ?></a>
+                        <?php else: ?>
+                            <?php echo $HTML->encode($entry['customerID'] ?? ''); ?>
+                        <?php endif; ?>
+                    </td>
+                    <td>
+                        <?php if ($link): ?>
+                            <a href="<?php echo $HTML->encode($link); ?>"><?php echo $HTML->encode($entry['billingDate'] ?? ''); ?></a>
+                        <?php else: ?>
+                            <?php echo $HTML->encode($entry['billingDate'] ?? ''); ?>
+                        <?php endif; ?>
+                    </td>
+                    <td>
+                        <?php if ($link): ?>
+                            <a href="<?php echo $HTML->encode($link); ?>"><?php echo $HTML->encode($entry['loggedAt'] ?? ''); ?></a>
+                        <?php else: ?>
+                            <?php echo $HTML->encode($entry['loggedAt'] ?? ''); ?>
+                        <?php endif; ?>
+                    </td>
+                    <td>
+                        <?php if ($link): ?>
+                            <a href="<?php echo $HTML->encode($link); ?>"><?php echo $HTML->encode($entry['status'] ?? ''); ?></a>
+                        <?php else: ?>
+                            <?php echo $HTML->encode($entry['status'] ?? ''); ?>
+                        <?php endif; ?>
+                    </td>
+                    <td>
+                        <?php if ($link): ?>
+                            <a class="button button-simple" href="<?php echo $HTML->encode($link); ?>"><?php echo $Lang->get('Open'); ?></a>
+                        <?php else: ?>
+                            &ndash;
+                        <?php endif; ?>
+                    </td>
                 </tr>
             <?php endforeach; ?>
             </tbody>

--- a/perch/addons/apps/perch_notification_logs/modes/logs.pre.php
+++ b/perch/addons/apps/perch_notification_logs/modes/logs.pre.php
@@ -3,6 +3,57 @@ $log_dir = realpath(__DIR__.'/../../../../../logs/notifications');
 //$log_dir  = __DIR__ . '/logs/notifications';
 //$log_dir  = __DIR__ . '/logs/notifications';
 $logs = [];
+
+$send_page_base = rtrim($API->app_path('perch_shop_orders'), '/') . '/package_admin/';
+$package_items_factory = null;
+$packages_factory = null;
+
+if (class_exists('PerchShop_PackageItems', true) && class_exists('PerchShop_Packages', true)) {
+    $shop_api = new PerchAPI(1.0, 'perch_shop');
+    $package_items_factory = new PerchShop_PackageItems($shop_api);
+    $packages_factory = new PerchShop_Packages($shop_api);
+}
+
+$build_link = function(array $entry) use ($send_page_base, $package_items_factory, $packages_factory) {
+    $query = [];
+
+    if (!empty($entry['itemID'])) {
+        $item_id = (int)$entry['itemID'];
+        if ($item_id > 0) {
+            $query['itemID'] = $item_id;
+
+            if ($package_items_factory && $packages_factory) {
+                $PackageItem = $package_items_factory->find($item_id);
+                if ($PackageItem) {
+                    $package_uuid = $PackageItem->packageID();
+                    if ($package_uuid) {
+                        $query['packageUUID'] = $package_uuid;
+
+                        $Package = $packages_factory->find_by_uuid($package_uuid);
+                        if ($Package) {
+                            $query['packageID'] = $Package->id();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (!empty($entry['customerID'])) {
+        $query['customerID'] = $entry['customerID'];
+    }
+
+    if (!empty($entry['billingDate'])) {
+        $query['billingDate'] = $entry['billingDate'];
+    }
+
+    if (empty($query)) {
+        return null;
+    }
+
+    return $send_page_base . '?' . http_build_query($query);
+};
+
 if ($log_dir && is_dir($log_dir)) {
     $files = glob($log_dir . '/send_payment_notification*.log');
     sort($files);
@@ -11,21 +62,25 @@ if ($log_dir && is_dir($log_dir)) {
         foreach (file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
             $parts = explode('|', $line);
             if (count($parts) >= 5) {
-                $entries[] = [
+                $entry = [
                     'itemID' => $parts[0],
                     'customerID' => $parts[1],
                     'billingDate' => $parts[2],
                     'loggedAt' => $parts[3],
                     'status' => $parts[4] ?? ''
                 ];
+                $entry['link'] = $build_link($entry);
+                $entries[] = $entry;
             } elseif (count($parts) >= 3) {
-                $entries[] = [
+                $entry = [
                     'itemID' => '',
                     'customerID' => $parts[0],
                     'billingDate' => $parts[1],
                     'loggedAt' => $parts[2],
                     'status' => $parts[3] ?? ''
                 ];
+                $entry['link'] = $build_link($entry);
+                $entries[] = $entry;
             }
         }
         $logs[basename($file)] = $entries;


### PR DESCRIPTION
## Summary
- derive links to the package notification page for each notification log entry
- render the admin log table with clickable values and a dedicated action to open the send-notification page

## Testing
- php -l perch/addons/apps/perch_notification_logs/modes/logs.pre.php
- php -l perch/addons/apps/perch_notification_logs/modes/logs.post.php

------
https://chatgpt.com/codex/tasks/task_b_68cbcddf1ea083249c2803193760dc92