### PR TITLE
Persist height unit radio choice

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
@@ -897,9 +897,10 @@ $Members = new PerchMembers_Members;
         if (!is_array($props)) $props = [];
 
 
-$props["height"]=$data["height"];
-$props["height2"]=$height2;
+        $props["height"]=$data["height"];
+        $props["height2"]=$height2;
  $props["heightunit"]= $data["heightunit"];
+        $props['heightunit-radio'] = $data['heightunit-radio'] ?? $data['heightunit'] ?? 'cm';
 $out=[];
  	$out['memberProperties'] = PerchUtil::json_safe_encode($props);
 


### PR DESCRIPTION
## Summary
- persist the normalized height unit radio selection in stored member questionnaire properties to keep height metadata complete

## Testing
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php

------
https://chatgpt.com/codex/tasks/task_b_68cbdf160670832482fae57c8b022394