### PR TITLE
Add pending orders admin listing

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Orders.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Orders.class.php
@@ -195,14 +195,31 @@ class PerchShop_Orders extends PerchShop_Factory
 
 		return $this->return_instances($rows);
 	}
-public function get_by_properties($details,$Paging=false){
+public function get_by_properties($details,$Paging=false,$statuses=null){
 //echo "get_by_properties";
 //print_r($details);
 $sort_val = null;
         $sort_dir = null;
 
 
-		if ($Paging && $Paging->enabled()) {
+        if ($statuses === null) {
+            $statuses = ['paid'];
+        }
+
+        if (!is_array($statuses)) {
+            $statuses = [$statuses];
+        }
+
+        $statuses = array_filter($statuses, function($status) {
+            return $status !== null && $status !== '';
+        });
+
+        if (!count($statuses)) {
+            $statuses = ['paid'];
+        }
+
+
+                if ($Paging && $Paging->enabled()) {
             $selectsql = $Paging->select_sql();
             list($sort_val, $sort_dir) = $Paging->get_custom_sort_options();
         }else{
@@ -213,7 +230,7 @@ $sort_val = null;
          $fromsql =  '      FROM ' . $this->table .' o LEFT JOIN '.PERCH_DB_PREFIX.'shop_packages pkg ON pkg.orderID=o.orderID, '.PERCH_DB_PREFIX.'shop_customers c ';
                 $wheresql = ' WHERE o.customerID=c.customerID
                                 AND o.orderDeleted IS NULL
-                                AND o.orderStatus IN ("paid")';
+                                AND o.orderStatus IN ('.$this->db->implode_for_sql_in($statuses).')';
                 	if($details["sendtopharmacy"]!=""){
                 	if($details["sendtopharmacy"]=="yes"){
                 	 // $selectsql .= ' ,p.* ';

--- a/perch/addons/apps/perch_shop_orders/modes/_subnav.php
+++ b/perch/addons/apps/perch_shop_orders/modes/_subnav.php
@@ -1,18 +1,19 @@
 <?php
 	PerchUI::set_subnav([
-		['page'=>[
-						'perch_shop_orders',
-						'perch_shop_orders/order',
-						'perch_shop_orders/order/edit',
-						'perch_shop_orders/order/evidence',
-						'perch_shop_orders/export',
-						], 
-				'label'=>'Orders'],
-		['page'=>[
-						'perch_shop_orders/customers',
-						'perch_shop_orders/customers/edit',
-						'perch_shop_orders/customers/delete',
-						], 
+                ['page'=>[
+                                                'perch_shop_orders',
+                                                'perch_shop_orders/order',
+                                                'perch_shop_orders/order/edit',
+                                                'perch_shop_orders/order/evidence',
+                                                'perch_shop_orders/export',
+                                                ],
+                                'label'=>'Orders'],
+                ['page'=>'perch_shop_orders/pending', 'label'=>'Pending Orders'],
+                ['page'=>[
+                                                'perch_shop_orders/customers',
+                                                'perch_shop_orders/customers/edit',
+                                                'perch_shop_orders/customers/delete',
+                                                ],
 				'label'=>'Customers'],
   ['page'=>'perch_shop_orders/packages', 'label'=>'Packages'],
 

--- a/perch/addons/apps/perch_shop_orders/modes/orders.list.post.php
+++ b/perch/addons/apps/perch_shop_orders/modes/orders.list.post.php
@@ -1,7 +1,11 @@
 <?php 
 
+if (!isset($list_heading)) {
+    $list_heading = $Lang->get('Listing all orders');
+}
+
 echo $HTML->title_panel([
-    'heading' => $Lang->get('Listing all orders'),
+    'heading' => $list_heading,
     'button'  => [
         'text' => $Lang->get('Add order'),
         'link' => $API->app_nav().'/order/edit/',

--- a/perch/addons/apps/perch_shop_orders/modes/orders.list.pre.php
+++ b/perch/addons/apps/perch_shop_orders/modes/orders.list.pre.php
@@ -2,10 +2,10 @@
 	$Paging = $API->get('Paging');
 	$Paging->set_per_page(24);
 $sort="^orderCreated";
-	$Orders   = new PerchShop_Orders($API);
-	$OrderItems = new PerchShop_OrderItems($API);
-	$Statuses = new PerchShop_OrderStatuses($API);
-	$Tags = new PerchMembers_Tags($API);
+        $Orders   = new PerchShop_Orders($API);
+        $OrderItems = new PerchShop_OrderItems($API);
+        $Statuses = new PerchShop_OrderStatuses($API);
+        $Tags = new PerchMembers_Tags($API);
  $Documents = new PerchMembers_Documents($API);
     $Template   = $API->get('Template');
     $Template->set('shop/orders/filter.html', 'shop');
@@ -14,6 +14,9 @@ $sort="^orderCreated";
     $Form->handle_empty_block_generation($Template);
 
      $details = array();
+    if (!isset($default_statuses) || !is_array($default_statuses) || !count($default_statuses)) {
+        $default_statuses = $Statuses->get_status_and_above('paid');
+    }
             if ($Form->submitted()) {
 
                    $post = $_POST;
@@ -24,10 +27,10 @@ $sort="^orderCreated";
 
                     $details=$data["orderDynamicFields"];
                 $details =json_decode($details, TRUE);
- $orders = $Orders->get_by_properties($details, $Paging);
+$orders = $Orders->get_by_properties($details, $Paging, $default_statuses);
 
 
                      }else{
-                     	$orders   = $Orders->get_admin_listing($Statuses->get_status_and_above('paid'), $Paging);
+                        $orders   = $Orders->get_admin_listing($default_statuses, $Paging);
 
                      }

--- a/perch/addons/apps/perch_shop_orders/modes/orders.pending.post.php
+++ b/perch/addons/apps/perch_shop_orders/modes/orders.pending.post.php
@@ -1,0 +1,3 @@
+<?php
+        $list_heading = $Lang->get('Listing pending orders');
+        include(__DIR__.'/orders.list.post.php');

--- a/perch/addons/apps/perch_shop_orders/modes/orders.pending.pre.php
+++ b/perch/addons/apps/perch_shop_orders/modes/orders.pending.pre.php
@@ -1,0 +1,3 @@
+<?php
+        $default_statuses = ['pending'];
+        include(__DIR__.'/orders.list.pre.php');

--- a/perch/addons/apps/perch_shop_orders/pending/index.php
+++ b/perch/addons/apps/perch_shop_orders/pending/index.php
@@ -1,0 +1,6 @@
+<?php
+        $mode  = 'orders.pending';
+        $title = 'Pending Orders';
+
+        include('../_default_index.php');
+


### PR DESCRIPTION
## Summary
- add a Pending Orders entry to the orders submenu
- introduce a pending orders mode that reuses the standard listing with a custom heading
- allow the order listing logic to accept configurable status filters so the pending view only shows pending orders

## Testing
- php -l perch/addons/apps/perch_shop_orders/modes/orders.list.pre.php
- php -l perch/addons/apps/perch_shop_orders/modes/orders.list.post.php
- php -l perch/addons/apps/perch_shop_orders/modes/orders.pending.pre.php
- php -l perch/addons/apps/perch_shop_orders/modes/orders.pending.post.php
- php -l perch/addons/apps/perch_shop_orders/modes/_subnav.php
- php -l perch/addons/apps/perch_shop_orders/pending/index.php
- php -l perch/addons/apps/perch_shop/lib/PerchShop_Orders.class.php

------
https://chatgpt.com/codex/tasks/task_b_68cc01710df08324b53093c0fc10c7bd