### PR TITLE
Redirect pending orders to success flow

### DIFF
--- a/perch/templates/pages/payment/stripe/index.php
+++ b/perch/templates/pages/payment/stripe/index.php
@@ -20,7 +20,21 @@ if (empty($_SESSION['questionnaire-reorder']) && isset($_COOKIE['questionnaire_r
        ]);
 
 
-        if ($result) {
+        $ShopRuntime = PerchShop_Runtime::fetch();
+        $ActiveOrder = $ShopRuntime->get_active_order();
+        $order_status = null;
+        if ($ActiveOrder) {
+            $order_status = strtolower((string)$ActiveOrder->orderStatus());
+        }
+
+        $successful_statuses = ['paid', 'pending'];
+        $redirect_to_success = in_array($order_status, $successful_statuses, true);
+
+        if (!$redirect_to_success && $result === true) {
+            $redirect_to_success = true;
+        }
+
+        if ($redirect_to_success) {
         if(isset($_SESSION['questionnaire-reorder']) && !empty($_SESSION['questionnaire-reorder'])){
         unset($_SESSION['questionnaire-reorder']['nextstep']);
     perch_member_add_questionnaire($_SESSION['questionnaire-reorder'],'re-order');

--- a/perch/templates/pages/payment/success/index.php
+++ b/perch/templates/pages/payment/success/index.php
@@ -17,6 +17,21 @@ setcookie('questionnaire', '', time()-3600, '/');
 setcookie('questionnaire_reorder', '', time()-3600, '/');
 setcookie('draft_package_item', '', time()-3600, '/');
 
+$order_is_paid = perch_shop_order_successful();
+$order_complete = $order_is_paid;
+
+if (!$order_complete) {
+    $ShopRuntime = PerchShop_Runtime::fetch();
+    $ActiveOrder = $ShopRuntime->get_active_order();
+
+    if ($ActiveOrder) {
+        $order_status = strtolower((string)$ActiveOrder->orderStatus());
+        if ($order_status === 'pending') {
+            $order_complete = true;
+        }
+    }
+}
+
      perch_layout('product/header', [
           'page_title' => perch_page_title(true),
       ]);
@@ -109,7 +124,7 @@ setcookie('draft_package_item', '', time()-3600, '/');
 <?php  } ?>
   <section class="shippin_section">
     <div class="container all_content mt-4">
-    <?php if (perch_shop_order_successful()) {
+    <?php if ($order_complete) {
     perch_shop_empty_cart();
     ?>
         <h2 class="text-center fw-bolder">Complete your consultation. <br/>Upload your identification document and video here.<br/>


### PR DESCRIPTION
## Summary
- treat Stripe checkout callbacks with a pending order status as successful so customers land on the success page
- update the success page to show the consultation instructions for pending orders and continue clearing the cart

## Testing
- php -l perch/templates/pages/payment/stripe/index.php
- php -l perch/templates/pages/payment/success/index.php

------
https://chatgpt.com/codex/tasks/task_b_68cc036db3d0832494f967a662d16ea8