### PR TITLE
Handle missing order items when listing orders

### DIFF
--- a/perch/addons/apps/perch_shop_orders/modes/orders.list.post.php
+++ b/perch/addons/apps/perch_shop_orders/modes/orders.list.post.php
@@ -44,9 +44,19 @@ echo $HTML->title_panel([
         ]);
      $Listing->add_col([
                 'title'     => 'Order Product',
-                'value'     => function($Item) use ($OrderItems){
+        'value'     => function($Item) use ($OrderItems){
                   $items = $OrderItems->get_for_admin($Item->id());
-                    $product = $items[0]->sku();
+                    if (!is_array($items) || empty($items)) {
+                        return "";
+                    }
+
+                    $first_item = reset($items);
+
+                    if (!is_object($first_item) || !method_exists($first_item, 'sku')) {
+                        return "";
+                    }
+
+                    $product = $first_item->sku();
                     if ($product == '') {
                         return "";
                     }


### PR DESCRIPTION
## Summary
- guard the order product column rendering when no order items are available to avoid calling sku on null

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cc1cf75c8083248e009f674381241c