### PR TITLE
Align Black ethnicity questionnaire value with Perch

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
@@ -89,7 +89,7 @@ public $doses = [
 
    /* protected $required_answers=[
     "age"=>["18to74"],
-     "ethnicity"=>["asian","African"],
+     "ethnicity"=>["asian","Black (African/Caribbean)"],
 
     ]*/
 

--- a/perch/addons/apps/perch_members/questionnaire_default_questions.php
+++ b/perch/addons/apps/perch_members/questionnaire_default_questions.php
@@ -122,7 +122,7 @@ return array (
       'options' => 
       array (
         'asian' => 'Asian or Asian British',
-        'black' => 'Black (Caribbean, African)',
+        'black' => 'Black (African/Caribbean)',
         'mixed' => 'Mixed ethnicities',
         'other' => 'Other ethnic group',
         'white' => 'White',

--- a/perch/templates/forms/questionnaire.html
+++ b/perch/templates/forms/questionnaire.html
@@ -115,8 +115,8 @@
                             <label for="asian" onclick="submitForm('ethnicity')"  id="asianlabel">Asian or Asian British</label>
 
 
-                            <input type="radio" name="ethnicity" onclick="submitForm('ethnicity')" id="African" value="African" <perch:if id="ethnicity" value="African"> checked="checked" </perch:if>>
-                            <label for="African" id="Africanlabel">Black (Caribbean, African)</label>
+                            <input type="radio" name="ethnicity" onclick="submitForm('ethnicity')" id="African" value="Black (African/Caribbean)" <perch:if id="ethnicity" value="Black (African/Caribbean)"> checked="checked" </perch:if>>
+                            <label for="African" id="Africanlabel">Black (African/Caribbean)</label>
 
 
                             <input type="radio" name="ethnicity" onclick="submitForm('ethnicity')"  id="Mixed"  value="Mixed" <perch:if id="ethnicity" value="Mixed"> checked="checked" </perch:if>>
@@ -174,7 +174,7 @@
             </div>
         </section>
     </perch:if>
-    <perch:if id="step" value="ethnicity,asian,African,White" match="within" >
+    <perch:if id="step" value="ethnicity,asian,Black (African/Caribbean),White" match="within" >
 
         <section class="how_old">
             <div class="contanier">

--- a/perch/templates/pages/getStarted/questionnaire.php
+++ b/perch/templates/pages/getStarted/questionnaire.php
@@ -295,7 +295,7 @@ $back_links = [
     'Other' => '/get-started/questionnaire?step=18to74',
     'Mixed' => '/get-started/questionnaire?step=18to74',
     'asian' => '/get-started/questionnaire?step=18to74',
-    'African' => '/get-started/questionnaire?step=18to74',
+    'Black (African/Caribbean)' => '/get-started/questionnaire?step=18to74',
     'White' => '/get-started/questionnaire?step=18to74',
     'ethnicity' => '/get-started/questionnaire?step=18to74',
     'Female' => '/get-started/questionnaire?step=ethnicity',


### PR DESCRIPTION
## Summary
- align the questionnaire radio value and label for the Black ethnicity option with the value expected in Perch
- update the back-link mapping and default questionnaire options to use the Black (African/Caribbean) wording consistently
- refresh the documented required answers list to reflect the new ethnicity value

## Testing
- php -l perch/templates/pages/getStarted/questionnaire.php
- php -l perch/addons/apps/perch_members/questionnaire_default_questions.php
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php

------
https://chatgpt.com/codex/tasks/task_b_68cd33c549e883249fcddb79060b74b2