### PR TITLE
Prevent PHP sort() errors in PerchAdminListing get_value

### DIFF
--- a/perch/core/lib/PerchAdminListing.class.php
+++ b/perch/core/lib/PerchAdminListing.class.php
@@ -590,23 +590,28 @@ class PerchAdminListing
 		return $this->HTML->encode($this->Lang->get($val), $escape_quotes);
 	}
 
-	private function get_value($def, $row, $use_prop=true)
-	{
-		if (is_bool($def)) {
-			return $def;
-		}
+        private function get_value($def, $row, $use_prop=true)
+        {
+                if (is_bool($def)) {
+                        return $def;
+                }
 
-		if (is_callable($def)) {
-			$func = $def;
-			return $func($row, $this->HTML, $this->Lang);
+                if ($use_prop && is_string($def) && strpos($def, '::') === false && strpos($def, '->') === false) {
+                        $prop = $def;
+                        return $this->HTML->encode($row->$prop());
+                }
 
-		} elseif ($use_prop) {
-			$prop = (string)$def;
-			return $this->HTML->encode($row->$prop());	
-		} else {
-			return $this->HTML->encode((string)$def);
-		}
-	}
+                if (is_callable($def)) {
+                        $func = $def;
+                        return $func($row, $this->HTML, $this->Lang);
+
+                } elseif ($use_prop) {
+                        $prop = (string)$def;
+                        return $this->HTML->encode($row->$prop());
+                } else {
+                        return $this->HTML->encode((string)$def);
+                }
+        }
 
 	private function format_value($def, $value)
 	{


### PR DESCRIPTION
## Summary
- ensure string column definitions default to row property lookups
- prevent accidentally invoking global functions such as sort() when rendering listings

## Testing
- php -l perch/core/lib/PerchAdminListing.class.php

------
https://chatgpt.com/codex/tasks/task_b_68cd3343d2088324ade396f5a689fa1f