### PR TITLE
Load questionnaire metadata from DB

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_QuestionnaireQuestion.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_QuestionnaireQuestion.class.php
@@ -3,5 +3,51 @@ class PerchMembers_QuestionnaireQuestion extends PerchAPI_Base
 {
     protected $table  = 'members_questionnaire_questions';
     protected $pk     = 'questionID';
+
+    /**
+     * Return the stored options decoded into an array.
+     *
+     * @return array
+     */
+    public function option_list()
+    {
+        $raw = $this->options();
+        if (!$raw) {
+            return [];
+        }
+
+        $decoded = PerchUtil::json_safe_decode($raw, true);
+        if (is_array($decoded)) {
+            return $decoded;
+        }
+
+        return [];
+    }
+
+    /**
+     * Provide a human readable summary of the available options.
+     *
+     * @return string
+     */
+    public function option_summary()
+    {
+        $options = $this->option_list();
+        if (!PerchUtil::count($options)) {
+            return '';
+        }
+
+        $pairs = [];
+        foreach ($options as $value => $label) {
+            if (is_array($label)) {
+                $display = isset($label['label']) ? $label['label'] : implode(' ', $label);
+            } else {
+                $display = $label;
+            }
+
+            $pairs[] = trim($display.' ['.$value.']');
+        }
+
+        return implode(', ', $pairs);
+    }
 }
 ?>

--- a/perch/addons/apps/perch_members/activate.php
+++ b/perch/addons/apps/perch_members/activate.php
@@ -83,7 +83,10 @@
           `questionKey` varchar(64) NOT NULL DEFAULT '',
           `label` varchar(255) NOT NULL,
           `type` char(32) NOT NULL DEFAULT 'text',
+          `fieldName` varchar(64) DEFAULT NULL,
+          `stepSlug` varchar(64) DEFAULT NULL,
           `options` text,
+          `dependencies` text,
           `sort` int(10) unsigned NOT NULL DEFAULT 0,
           PRIMARY KEY (`questionID`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -121,7 +124,10 @@
                     'questionKey'       => $key,
                     'label'             => $q['label'],
                     'type'              => $q['type'],
+                    'fieldName'         => isset($q['name']) ? $q['name'] : $key,
+                    'stepSlug'          => isset($q['step']) ? $q['step'] : $key,
                     'options'           => isset($q['options']) ? PerchUtil::json_safe_encode($q['options']) : null,
+                    'dependencies'      => isset($q['dependencies']) ? PerchUtil::json_safe_encode($q['dependencies']) : null,
                     'sort'              => $sort,
                 ]);
             }
@@ -134,7 +140,10 @@
                     'questionKey'       => $key,
                     'label'             => $q['label'],
                     'type'              => $q['type'],
+                    'fieldName'         => isset($q['name']) ? $q['name'] : $key,
+                    'stepSlug'          => isset($q['step']) ? $q['step'] : $key,
                     'options'           => isset($q['options']) ? PerchUtil::json_safe_encode($q['options']) : null,
+                    'dependencies'      => isset($q['dependencies']) ? PerchUtil::json_safe_encode($q['dependencies']) : null,
                     'sort'              => $sort,
                 ]);
             }

--- a/perch/addons/apps/perch_members/import_questionnaire_questions.php
+++ b/perch/addons/apps/perch_members/import_questionnaire_questions.php
@@ -26,7 +26,10 @@ foreach ($data['reorder'] as $key => $q) {
         'questionKey'       => $key,
         'label'             => $q['label'],
         'type'              => $q['type'],
+        'fieldName'         => isset($q['name']) ? $q['name'] : $key,
+        'stepSlug'          => isset($q['step']) ? $q['step'] : $key,
         'options'           => isset($q['options']) ? PerchUtil::json_safe_encode($q['options']) : null,
+        'dependencies'      => isset($q['dependencies']) ? PerchUtil::json_safe_encode($q['dependencies']) : null,
         'sort'              => $sort,
     ]);
 }
@@ -39,7 +42,10 @@ foreach ($data['first-order'] as $key => $q) {
         'questionKey'       => $key,
         'label'             => $q['label'],
         'type'              => $q['type'],
+        'fieldName'         => isset($q['name']) ? $q['name'] : $key,
+        'stepSlug'          => isset($q['step']) ? $q['step'] : $key,
         'options'           => isset($q['options']) ? PerchUtil::json_safe_encode($q['options']) : null,
+        'dependencies'      => isset($q['dependencies']) ? PerchUtil::json_safe_encode($q['dependencies']) : null,
         'sort'              => $sort,
     ]);
 }

--- a/perch/addons/apps/perch_members/modes/questions.list.post.php
+++ b/perch/addons/apps/perch_members/modes/questions.list.post.php
@@ -26,10 +26,27 @@
         ]);
 
     $Listing->add_col([
-
-            'title'     => 'Type',
+            'title'     => $Lang->get('Questionnaire type'),
             'value'     => 'questionnaireType',
             'sort'      => 'questionnaireType',
+        ]);
+
+    $Listing->add_col([
+            'title'     => $Lang->get('Answer type'),
+            'value'     => 'type',
+            'sort'      => 'type',
+        ]);
+
+    $Listing->add_col([
+            'title' => $Lang->get('Answers'),
+            'value' => function ($Question, $HTML, $Lang) {
+                $summary = $Question->option_summary();
+                if ($summary === '') {
+                    return $HTML->encode($Lang->get('None'));
+                }
+
+                return $HTML->encode($summary);
+            },
         ]);
 
     echo $Listing->render($questions);

--- a/perch/addons/apps/perch_members/questionnaire_default_questions.php
+++ b/perch/addons/apps/perch_members/questionnaire_default_questions.php
@@ -1,389 +1,519 @@
 <?php
-return array (
-  'reorder' => 
-  array (
-    'weight' => 
-    array (
-      'label' => 'What is your current weight?',
-      'type' => 'text',
-      'name' => 'weight',
-    ),
-    'weight2' => 
-    array (
-      'label' => 'Weight (lbs hidden input)',
-      'type' => 'hidden',
-      'name' => 'weight2',
-    ),
-    'weightunit' => 
-    array (
-      'label' => 'Weight Unit (kg or st/lbs)',
-      'type' => 'radio',
-      'name' => 'weightradio-unit',
-      'options' => 
-      array (
-        'kg' => 'kg',
-        'st-lbs' => 'st/lbs',
-      ),
-    ),
-    'side_effects' => 
-    array (
-      'label' => 'Have you experienced any side effects whilst taking the medication?',
-      'type' => 'button',
-      'name' => 'more_side_effects',
-      'options' => 
-      array (
-        'yes' => 'Yes',
-        'no' => 'No',
-      ),
-    ),
-    'more_side_effects' => 
-    array (
-      'label' => 'Please tell us as much as you can about your side effects - the type, duration, severity and whether they have resolved.',
-      'type' => 'textarea',
-      'name' => 'more_side_effects',
-    ),
-    'additional_medication' => 
-    array (
-      'label' => 'Have you started taking any additional medication?',
-      'type' => 'button',
-      'name' => 'additional-medication',
-      'options' => 
-      array (
-        'yes' => 'Yes',
-        'no' => 'No',
-      ),
-    ),
-    'list_additional_medication' => 
-    array (
-      'label' => 'Please tell us as much as you can about your side effects - the type, duration, severity and whether they have resolved.',
-      'type' => 'textarea',
-      'name' => 'list_additional_medication',
-    ),
-    'rate_current_experience' => 
-    array (
-      'label' => 'Are you happy with your monthly weight loss?',
-      'type' => 'button',
-      'name' => 'rate_current_experience',
-      'options' => 
-      array (
-        'yes' => 'Yes',
-        'no' => 'No',
-      ),
-    ),
-    'no_happy_reasons' => 
-    array (
-      'label' => 'Please tell us as much as you can about the reasons you are not happy with your monthly weight loss.',
-      'type' => 'textarea',
-      'name' => 'no_happy_reasons',
-    ),
-    'chat_with_us' => 
-    array (
-      'label' => 'Would you like to chat with someone?',
-      'type' => 'button',
-      'name' => 'chat_with_us',
-      'options' => 
-      array (
-        'yes' => 'Yes',
-        'no' => 'No',
-      ),
-    ),
-    'email_address' => 
-    array (
-      'label' => 'Please enter your  email address',
-      'type' => 'text',
-      'name' => 'email_address',
-    ),
-  ),
-  'first-order' => 
-  array (
-    'consultation' => 
-    array (
-      'label' => 'agree-consultation',
-      'type' => 'text',
-      'name' => 'consultation',
-    ),
-    'age' => 
-    array (
-      'label' => 'How old are you?',
-      'type' => 'radio',
-      'name' => 'age',
-      'options' => 
-      array (
-        'under18' => 'Under 18',
-        '18to74' => '18 to 74',
-        '75over' => '75 or over',
-      ),
-    ),
-    'ethnicity' => 
-    array (
-      'label' => 'Which ethnicity are you?',
-      'type' => 'radio',
-      'name' => 'ethnicity',
-      'options' => 
-      array (
-        'asian' => 'Asian or Asian British',
-        'black' => 'Black (African/Caribbean)',
-        'mixed' => 'Mixed ethnicities',
-        'other' => 'Other ethnic group',
-        'white' => 'White',
-      ),
-    ),
-    'ethnicity-more' => 
-    array (
-      'label' => 'Please tell us which ethnicities',
-      'type' => 'text',
-      'name' => 'ethnicity-more',
-    ),
-    'gender' => 
-    array (
-      'label' => 'What sex were you assigned at birth?',
-      'type' => 'radio',
-      'name' => 'gender',
-      'options' => 
-      array (
-        'male' => 'Male',
-        'female' => 'Female',
-      ),
-    ),
-    'pregnancy' => 
-    array (
-      'label' => 'Are you currently pregnant, trying to get pregnant, or breastfeeding?',
-      'type' => 'radio',
-      'name' => 'pregnancy',
-      'options' => 
-      array (
-        'yes' => 'Yes',
-        'no' => 'No',
-      ),
-    ),
-    'weight' => 
-    array (
-      'label' => 'What is your weight?',
-      'type' => 'text',
-      'name' => 'weight',
-    ),
-    'weightunit' => 
-    array (
-      'label' => 'weight unit',
-      'type' => 'radio',
-      'name' => 'weightradio-unit',
-      'options' => 
-      array (
-        'kg' => 'kg',
-        'st' => 'st/lbs',
-      ),
-    ),
-    'height' => 
-    array (
-      'label' => 'What is your height?',
-      'type' => 'text',
-      'name' => 'height',
-    ),
-    'heightunit' => 
-    array (
-      'label' => 'height unit',
-      'type' => 'radio',
-      'name' => 'heightunit-radio',
-      'options' => 
-      array (
-        'cm' => 'cm',
-        'ft-in' => 'ft/in',
-      ),
-    ),
-    'diabetes' => 
-    array (
-      'label' => 'Have you been diagnosed with diabetes?',
-      'type' => 'radio',
-      'name' => 'diabetes',
-      'options' => 
-      array (
-        'medicated' => 'I have diabetes and take medication for it',
-        'diet' => 'I have diabetes and it\'s diet-controlled',
-        'family-history' => 'No, but there is history of diabetes in my family',
-        'pre-diabetes' => 'I have pre-diabetes',
-        'none' => 'I don\'t have diabetes',
-      ),
-    ),
-    'conditions' => 
-    array (
-      'label' => 'Do any of the following statements apply to you?',
-      'type' => 'checkbox',
-      'name' => 'conditions[]',
-      'options' => 
-      array (
-        'malabsorption' => 'I have chronic malabsorption syndrome (problems absorbing food)',
-        'cholestasis' => 'I have cholestasis',
-        'cancer' => 'I’m currently being treated for cancer',
-        'retinopathy' => 'I have diabetic retinopathy',
-        'heart-failure' => 'I have severe heart failure',
-        'thyroid-cancer' => 'I have a family history of thyroid cancer and/or I’ve had thyroid cancer',
-        'men2' => 'I have Multiple endocrine neoplasia type 2 (MEN2)',
-        'pancreatitis' => 'I have a history of pancreatitis',
-        'eating-disorder' => 'I have or have had an eating disorder such as bulimia, anorexia nervosa, or a binge eating disorder',
-        'thyroid-op' => 'I have had surgery or an operation to my thyroid',
-        'bariatric-op' => 'I have had a bariatric operation such as gastric band or sleeve surgery',
-        'none' => 'None of these statements apply to me',
-      ),
-    ),
-    'bariatricoperation' => 
-    array (
-      'label' => 'Was your bariatric operation in the last 6 months?',
-      'type' => 'radio',
-      'name' => 'bariatricoperation',
-      'options' => 
-      array (
-        'yes' => 'Yes',
-        'no' => 'No',
-      ),
-    ),
-    'more_pancreatitis' => 
-    array (
-      'label' => 'Please tell us more about your health condition and how you manage it.',
-      'type' => 'text',
-      'name' => 'more_pancreatitis',
-    ),
-    'thyroidoperation' => 
-    array (
-      'label' => 'Please tell us further details on the thyroid surgery you had, the outcome of the surgery and any ongoing monitoring',
-      'type' => 'text',
-      'name' => 'thyroidoperation',
-    ),
-    'conditions2' => 
-    array (
-      'label' => 'Do any of the following statements apply to you?',
-      'type' => 'checkbox',
-      'name' => 'conditions2[]',
-      'options' => 
-      array (
-        'mentalhealth' => 'I have been diagnosed with a mental health condition such as depression or anxiety',
-        'social-anxiety' => 'My weight makes me anxious in social situations',
-        'joint-pain' => 'I have joint pains and/or aches',
-        'osteoarthritis' => 'I have osteoarthritis',
-        'gord' => 'I have GORD and/or indigestion',
-        'cardio' => 'I have a heart/cardiovascular problem',
-        'bp' => 'I’ve been diagnosed with, or have a family history of, high blood pressure',
-        'cholesterol' => 'I’ve been diagnosed with, or have a family history of, high cholesterol',
-        'fatty-liver' => 'I have fatty liver disease',
-        'apnoea' => 'I have sleep apnoea',
-        'asthma' => 'I have asthma or COPD',
-        'ed' => 'I have erectile dysfunction',
-        'low-t' => 'I have low testosterone',
-        'menopause' => 'I have menopausal symptoms',
-        'pcos' => 'I have polycystic ovary syndrome (PCOS)',
-        'none' => 'None of these statements apply to me',
-      ),
-    ),
-    'medical_conditions' => 
-    array (
-      'label' => 'Do you have any other medical conditions?',
-      'type' => 'radio',
-      'name' => 'medical_conditions',
-      'options' => 
-      array (
-        'yes' => 'Yes',
-        'no' => 'No',
-      ),
-    ),
-    'medications' => 
-    array (
-      'label' => 'Have you ever taken any of the following medications to help you lose weight?',
-      'type' => 'checkbox',
-      'name' => 'medications[]',
-      'options' => 
-      array (
-        'wegovy' => 'Wegovy',
-        'ozempic' => 'Ozempic',
-        'saxenda' => 'Saxenda',
-        'rybelsus' => 'Rybelsus',
-        'mounjaro' => 'Mounjaro',
-        'alli' => 'Alli',
-        'mysimba' => 'Mysimba',
-        'other' => 'Other',
-        'never' => 'I have never taken medication to lose weight',
-      ),
-    ),
-    'weight-wegovy' => 
-    array (
-      'label' => 'What was your weight in kg before starting the weight loss medication?',
-      'type' => 'text',
-      'name' => 'weight-wegovy',
-    ),
-    'dose-wegovy' => 
-    array (
-      'label' => 'When was your last dose of the weight loss medication?',
-      'type' => 'radio',
-      'name' => 'dose-wegovy',
-      'options' => 
-      array (
-        'lt4' => 'Less than 4 weeks ago',
-        '4-6' => '4–6 weeks ago',
-        'gt6' => 'More than 6 weeks ago',
-      ),
-    ),
-    'recently-dose-wegovy' => 
-    array (
-      'label' => 'What dose of the weight loss medication were you prescribed most recently?',
-      'type' => 'radio',
-      'name' => 'recently-dose-wegovy',
-      'options' => 
-      array (
-        '0.25' => '0.25mg/2.5mg',
-        '0.5' => '0.5mg/5mg',
-        '1.0' => '1mg/7.5mg',
-        '1.7' => '1.7mg/12.5mg',
-        '2.4' => '2.4mg/15mg',
-        'other' => 'Other',
-      ),
-    ),
-    'continue-dose-wegovy' => 
-    array (
-      'label' => 'What dose would you like to continue with?',
-      'type' => 'radio',
-      'name' => 'continue-dose-wegovy',
-      'options' => 
-      array (
-        'increase' => 'Increase my dose',
-        'keep' => 'Keep my dose',
-        'decrease' => 'Decrease my dose',
-        'stop' => 'I don\'t want to continue with this medication',
-      ),
-    ),
-    'effects_with_wegovy' => 
-    array (
-      'label' => 'Have you experienced any side effects with the weight loss medication?',
-      'type' => 'radio',
-      'name' => 'effects_with_wegovy',
-      'options' => 
-      array (
-        'yes' => 'Yes',
-        'no' => 'No',
-      ),
-    ),
-    'wegovy_side_effects' => 
-    array (
-      'label' => 'Please tell us as much as you can about your side effects',
-      'type' => 'text',
-      'name' => 'wegovy_side_effects',
-    ),
-    'medication_allergies' => 
-    array (
-      'label' => 'Do you currently take any other medication or have any allergies?',
-      'type' => 'checkbox',
-      'name' => 'medication_allergies[]',
-      'options' => 
-      array (
-        'levothyroxine' => 'I’m on levothyroxine',
-        'warfarin' => 'I’m on warfarin',
-        'multiple' => 'Other / I take more than one prescription medication',
-        'none' => 'I don’t take any medication',
-        'allergy' => 'I have allergies',
-      ),
-    ),
-    'email_address' => 
-    array (
-      'label' => 'Please enter your GP\'s email address',
-      'type' => 'text',
-      'name' => 'email_address',
-    ),
-  ),
-);
+
+return [
+    'reorder' => [
+        'weight' => [
+            'label' => 'What is your current weight?',
+            'type' => 'text',
+            'name' => 'weight',
+            'step' => 'weight',
+        ],
+        'weight2' => [
+            'label' => 'Weight (secondary value)',
+            'type' => 'hidden',
+            'name' => 'weight2',
+            'step' => 'weight',
+        ],
+        'weightunit' => [
+            'label' => 'Weight unit',
+            'type' => 'radio',
+            'name' => 'weightradio-unit',
+            'options' => [
+                'kg' => 'kg',
+                'st-lbs' => 'st/lbs',
+            ],
+            'step' => 'weight',
+        ],
+        'side_effects' => [
+            'label' => 'Have you experienced any side effects whilst taking the medication?',
+            'type' => 'radio',
+            'name' => 'side_effects',
+            'options' => [
+                'yes' => 'Yes',
+                'no' => 'No',
+            ],
+            'step' => 'side-effects',
+            'dependencies' => [
+                [
+                    'values' => ['yes'],
+                    'question' => 'more_side_effects',
+                    'step' => 'more_side_effects',
+                ],
+            ],
+        ],
+        'more_side_effects' => [
+            'label' => 'Please tell us as much as you can about your side effects - the type, duration, severity and whether they have resolved.',
+            'type' => 'textarea',
+            'name' => 'more_side_effects',
+            'step' => 'more_side_effects',
+        ],
+        'additional_medication' => [
+            'label' => 'Have you started taking any additional medication?',
+            'type' => 'radio',
+            'name' => 'additional-medication',
+            'options' => [
+                'yes' => 'Yes',
+                'no' => 'No',
+            ],
+            'step' => 'additional-medication',
+            'dependencies' => [
+                [
+                    'values' => ['yes'],
+                    'question' => 'list_additional_medication',
+                    'step' => 'list_additional_medication',
+                ],
+            ],
+        ],
+        'list_additional_medication' => [
+            'label' => 'Please tell us as much as you can about your additional medication - the type, duration, severity and whether any side effects have resolved.',
+            'type' => 'textarea',
+            'name' => 'list_additional_medication',
+            'step' => 'list_additional_medication',
+        ],
+        'rate_current_experience' => [
+            'label' => 'Are you happy with your monthly weight loss?',
+            'type' => 'radio',
+            'name' => 'rate_current_experience',
+            'options' => [
+                'yes' => 'Yes',
+                'no' => 'No',
+            ],
+            'step' => 'rate_current_experience',
+            'dependencies' => [
+                [
+                    'values' => ['no'],
+                    'question' => 'no_happy_reasons',
+                    'step' => 'no-happy',
+                ],
+            ],
+        ],
+        'no_happy_reasons' => [
+            'label' => 'Please tell us as much as you can about the reasons you are not happy with your monthly weight loss.',
+            'type' => 'textarea',
+            'name' => 'no_happy_reasons',
+            'step' => 'no-happy',
+        ],
+        'chat_with_us' => [
+            'label' => 'Would you like to chat with someone?',
+            'type' => 'radio',
+            'name' => 'chat_with_us',
+            'options' => [
+                'yes' => 'Yes',
+                'no' => 'No',
+            ],
+            'step' => 'chat_with_us',
+            'dependencies' => [
+                [
+                    'values' => ['yes'],
+                    'question' => 'email_address',
+                    'step' => 'contact',
+                ],
+            ],
+        ],
+        'email_address' => [
+            'label' => 'Please enter your email address',
+            'type' => 'text',
+            'name' => 'email_address',
+            'step' => 'contact',
+        ],
+    ],
+    'first-order' => [
+        'age' => [
+            'label' => 'How old are you?',
+            'type' => 'radio',
+            'name' => 'age',
+            'options' => [
+                'under18' => 'Under 18',
+                '18to74' => 'Older than 18 or Younger than 75',
+                '75over' => '75 or over',
+            ],
+            'step' => 'howold',
+        ],
+        'ethnicity' => [
+            'label' => 'Which ethnicity are you?',
+            'type' => 'radio',
+            'name' => 'ethnicity',
+            'options' => [
+                'asian' => 'Asian or Asian British',
+                'Black (African/Caribbean)' => 'Black (African/Caribbean)',
+                'Mixed' => 'Mixed ethnicities',
+                'Other' => 'Other ethnic group',
+                'White' => 'White',
+            ],
+            'step' => '18to74',
+            'dependencies' => [
+                [
+                    'values' => ['Mixed', 'Other'],
+                    'question' => 'ethnicity-more',
+                    'step' => 'Mixed',
+                ],
+            ],
+        ],
+        'ethnicity-more' => [
+            'label' => 'Please tell us which ethnicities',
+            'type' => 'textarea',
+            'name' => 'ethnicity-more',
+            'step' => 'Mixed',
+        ],
+        'gender' => [
+            'label' => 'What sex were you assigned at birth?',
+            'type' => 'radio',
+            'name' => 'gender',
+            'options' => [
+                'Male' => 'Male',
+                'Female' => 'Female',
+            ],
+            'step' => 'ethnicity',
+            'dependencies' => [
+                [
+                    'values' => ['Female'],
+                    'question' => 'pregnancy',
+                    'step' => 'Female',
+                ],
+            ],
+        ],
+        'pregnancy' => [
+            'label' => 'Are you currently pregnant, trying to get pregnant, or breastfeeding?',
+            'type' => 'radio',
+            'name' => 'pregnancy',
+            'options' => [
+                'yes' => 'Yes',
+                'no' => 'No',
+            ],
+            'step' => 'Female',
+            'dependencies' => [
+                [
+                    'values' => ['yes'],
+                    'step' => 'pregnancy',
+                ],
+            ],
+        ],
+        'weight' => [
+            'label' => 'What is your weight?',
+            'type' => 'text',
+            'name' => 'weight',
+            'step' => 'weight',
+        ],
+        'weight2' => [
+            'label' => 'Weight (secondary value)',
+            'type' => 'hidden',
+            'name' => 'weight2',
+            'step' => 'weight',
+        ],
+        'weightunit' => [
+            'label' => 'Weight unit',
+            'type' => 'radio',
+            'name' => 'weightradio-unit',
+            'options' => [
+                'kg' => 'kg',
+                'st-lbs' => 'st/lbs',
+            ],
+            'step' => 'weight',
+        ],
+        'height' => [
+            'label' => 'What is your height?',
+            'type' => 'text',
+            'name' => 'height',
+            'step' => 'height',
+        ],
+        'height2' => [
+            'label' => 'Height (secondary value)',
+            'type' => 'hidden',
+            'name' => 'height2',
+            'step' => 'height',
+        ],
+        'heightunit' => [
+            'label' => 'Height unit',
+            'type' => 'radio',
+            'name' => 'heightunit-radio',
+            'options' => [
+                'cm' => 'cm',
+                'ft-in' => 'ft/in',
+            ],
+            'step' => 'height',
+        ],
+        'diabetes' => [
+            'label' => 'Have you been diagnosed with diabetes?',
+            'type' => 'radio',
+            'name' => 'diabetes',
+            'options' => [
+                'yes-medication' => 'I have diabetes and take medication for it',
+                'yes-diet' => 'I have diabetes and it\'s diet-controlled',
+                'nohistory' => 'No, but there is history of diabetes in my family',
+                'pre-diabetes' => 'I have pre-diabetes',
+                'no' => 'I don\'t have diabetes',
+            ],
+            'step' => 'diabetes',
+        ],
+        'conditions' => [
+            'label' => 'Do any of the following statements apply to you?',
+            'type' => 'checkbox',
+            'name' => 'conditions[]',
+            'options' => [
+                'malabsorption' => 'I have chronic malabsorption syndrome (problems absorbing food)',
+                'cholestasis' => 'I have cholestasis',
+                'cancer' => 'I’m currently being treated for cancer',
+                'retinopathy' => 'I have diabetic retinopathy',
+                'heartfailure' => 'I have severe heart failure',
+                'familythyroid' => 'I have a family history of thyroid cancer and/or I’ve had thyroid cancer',
+                'neoplasia' => 'I have Multiple endocrine neoplasia type 2 (MEN2)',
+                'pancreatitishistory' => 'I have a history of pancreatitis',
+                'eatingdisorder' => 'I have or have had an eating disorder such as bulimia, anorexia nervosa, or a binge eating disorder',
+                'thyroidoperation' => 'I have had surgery or an operation to my thyroid',
+                'bariatricoperation' => 'I have had a bariatric operation such as gastric band or sleeve surgery',
+                'none' => 'None of these statements apply to me',
+            ],
+            'step' => 'weight2',
+            'dependencies' => [
+                [
+                    'values' => ['pancreatitishistory'],
+                    'step' => 'history_pancreatitis',
+                ],
+                [
+                    'values' => ['thyroidoperation'],
+                    'question' => 'thyroidoperation',
+                    'step' => 'thyroidoperation',
+                ],
+                [
+                    'values' => ['bariatricoperation'],
+                    'question' => 'bariatricoperation',
+                    'step' => 'bariatricoperation',
+                ],
+                [
+                    'values' => ['eatingdisorder'],
+                    'question' => 'more_conditions',
+                    'step' => 'more',
+                ],
+            ],
+        ],
+        'bariatricoperation' => [
+            'label' => 'Was your bariatric operation in the last 6 months?',
+            'type' => 'radio',
+            'name' => 'bariatricoperation',
+            'options' => [
+                'yes' => 'Yes',
+                'no' => 'No',
+            ],
+            'step' => 'bariatricoperation',
+            'dependencies' => [
+                [
+                    'values' => ['yes'],
+                    'step' => 'history_pancreatitis',
+                ],
+            ],
+        ],
+        'more_pancreatitis' => [
+            'label' => 'Please tell us more about your health condition and how you manage it.',
+            'type' => 'textarea',
+            'name' => 'more_pancreatitis',
+            'step' => 'more_pancreatitis',
+        ],
+        'thyroidoperation' => [
+            'label' => 'Please tell us further details on the thyroid surgery you had, the outcome of the surgery and any ongoing monitoring',
+            'type' => 'textarea',
+            'name' => 'thyroidoperation',
+            'step' => 'thyroidoperation',
+        ],
+        'more_conditions' => [
+            'label' => 'Please tell us more about your health condition and how you manage it.',
+            'type' => 'textarea',
+            'name' => 'more_conditions',
+            'step' => 'more',
+        ],
+        'conditions2' => [
+            'label' => 'Do any of the following statements apply to you?',
+            'type' => 'checkbox',
+            'name' => 'conditions2[]',
+            'options' => [
+                'mentalhealth' => 'I have been diagnosed with a mental health condition such as depression or anxiety',
+                'anxious' => 'My weight makes me anxious in social situations',
+                'joint' => 'I have joint pains and/or aches',
+                'osteoarthritis' => 'I have osteoarthritis',
+                'indigestion' => 'I have GORD and/or indigestion',
+                'cardiovascular' => 'I have a heart/cardiovascular problem',
+                'bloodpressure' => 'I’ve been diagnosed with, or have a family history of, high blood pressure',
+                'cholesterol' => 'I’ve been diagnosed with, or have a family history of, high cholesterol',
+                'fattyliver' => 'I have fatty liver disease',
+                'apnoea' => 'I have sleep apnoea',
+                'asthma' => 'I have asthma or COPD',
+                'erectile' => 'I have erectile dysfunction',
+                'testosterone' => 'I have low testosterone',
+                'menopausal' => 'I have menopausal symptoms',
+                'pcos' => 'I have polycystic ovary syndrome (PCOS)',
+                'none' => 'None of these statements apply to me',
+            ],
+            'step' => 'conditions',
+        ],
+        'medical_conditions' => [
+            'label' => 'Do you have any other medical conditions?',
+            'type' => 'radio',
+            'name' => 'medical_conditions',
+            'options' => [
+                'yes' => 'Yes',
+                'no' => 'No',
+            ],
+            'step' => 'medical_conditions',
+            'dependencies' => [
+                [
+                    'values' => ['yes'],
+                    'question' => 'other_medical_conditions',
+                    'step' => 'list_any',
+                ],
+            ],
+        ],
+        'other_medical_conditions' => [
+            'label' => 'Please list your other medical conditions.',
+            'type' => 'textarea',
+            'name' => 'other_medical_conditions',
+            'step' => 'list_any',
+        ],
+        'medications' => [
+            'label' => 'Have you ever taken any of the following medications to help you lose weight?',
+            'type' => 'checkbox',
+            'name' => 'medications[]',
+            'options' => [
+                'wegovy' => 'Wegovy',
+                'ozempic' => 'Ozempic',
+                'saxenda' => 'Saxenda',
+                'rybelsus' => 'Rybelsus',
+                'mounjaro' => 'Mounjaro',
+                'alli' => 'Alli',
+                'mysimba' => 'Mysimba',
+                'other' => 'Other',
+                'none' => 'I have never taken medication to lose weight',
+            ],
+            'step' => 'medications',
+            'dependencies' => [
+                [
+                    'values' => ['wegovy', 'ozempic', 'saxenda', 'rybelsus', 'mounjaro', 'alli', 'mysimba', 'other'],
+                    'question' => 'weight-wegovy',
+                    'step' => 'starting_wegovy',
+                ],
+            ],
+        ],
+        'weight-wegovy' => [
+            'label' => 'What was your weight before starting the weight loss medication?',
+            'type' => 'text',
+            'name' => 'weight-wegovy',
+            'step' => 'starting_wegovy',
+        ],
+        'weight2-wegovy' => [
+            'label' => 'Weight before medication (secondary value)',
+            'type' => 'hidden',
+            'name' => 'weight2-wegovy',
+            'step' => 'starting_wegovy',
+        ],
+        'unit-wegovy' => [
+            'label' => 'Weight before medication unit',
+            'type' => 'radio',
+            'name' => 'unit-wegovy',
+            'options' => [
+                'kg' => 'kg',
+                'st-lbs' => 'st/lbs',
+            ],
+            'step' => 'starting_wegovy',
+        ],
+        'dose-wegovy' => [
+            'label' => 'When was your last dose of the weight loss medication?',
+            'type' => 'radio',
+            'name' => 'dose-wegovy',
+            'options' => [
+                'less4' => 'Less than 4 weeks ago',
+                '4to6' => '4-6 weeks ago',
+                'over6' => 'More than 6 weeks ago',
+            ],
+            'step' => 'dose_wegovy',
+        ],
+        'recently-dose-wegovy' => [
+            'label' => 'What dose of the weight loss medication were you prescribed most recently?',
+            'type' => 'radio',
+            'name' => 'recently-dose-wegovy',
+            'options' => [
+                '25mg' => '0.25mg/2.5mg',
+                '05mg' => '0.5mg/5mg',
+                '1mg' => '1mg/7.5mg',
+                '17mg' => '1.7mg/12.5mg',
+                '24mg' => '2.4mg/15mg',
+                'other' => 'Other',
+            ],
+            'step' => 'recently_wegovy',
+        ],
+        'continue-dose-wegovy' => [
+            'label' => 'If you want to continue with the weight loss medication, what dose would you like to continue with?',
+            'type' => 'radio',
+            'name' => 'continue-dose-wegovy',
+            'options' => [
+                'increase' => 'Increase my dose',
+                'keep' => 'Keep my dose',
+                'decrease' => 'Decrease my dose',
+                'stop' => 'I don\'t want to continue with this medication',
+            ],
+            'step' => 'continue_with_wegovy',
+        ],
+        'effects_with_wegovy' => [
+            'label' => 'Have you experienced any side effects with the weight loss medication?',
+            'type' => 'radio',
+            'name' => 'effects_with_wegovy',
+            'options' => [
+                'yes' => 'Yes',
+                'no' => 'No',
+            ],
+            'step' => 'effects_with_wegovy',
+            'dependencies' => [
+                [
+                    'values' => ['yes'],
+                    'question' => 'wegovy_side_effects',
+                    'step' => 'wegovy_side_effects',
+                ],
+            ],
+        ],
+        'wegovy_side_effects' => [
+            'label' => 'Please tell us as much as you can about your side effects',
+            'type' => 'textarea',
+            'name' => 'wegovy_side_effects',
+            'step' => 'wegovy_side_effects',
+        ],
+        'medication_allergies' => [
+            'label' => 'Do you currently take any other medication or have any allergies?',
+            'type' => 'checkbox',
+            'name' => 'medication_allergies[]',
+            'options' => [
+                'levothyroxine' => 'I’m on levothyroxine',
+                'warfarin' => 'I’m on warfarin',
+                'other' => 'Other / I take more than one prescription medication',
+                'no-medication' => 'I don’t take any medication',
+                'allergies' => 'I have allergies',
+            ],
+            'step' => 'medication_allergies',
+        ],
+        'gp_informed' => [
+            'label' => 'Would you like your GP to be informed of this consultation?',
+            'type' => 'radio',
+            'name' => 'gp_informed',
+            'options' => [
+                'yes' => 'Yes',
+                'no' => 'No',
+            ],
+            'step' => 'gp_informed',
+            'dependencies' => [
+                [
+                    'values' => ['yes'],
+                    'question' => 'GP_email_address',
+                    'step' => 'gp_address',
+                ],
+            ],
+        ],
+        'GP_email_address' => [
+            'label' => 'Please enter your GP\'s email address',
+            'type' => 'text',
+            'name' => 'GP_email_address',
+            'step' => 'gp_address',
+        ],
+        'access_special_offers' => [
+            'label' => 'Get access to special offers',
+            'type' => 'text',
+            'name' => 'email_address',
+            'step' => 'access_special_offers',
+        ],
+    ],
+];

--- a/perch/addons/apps/perch_members/runtime.php
+++ b/perch/addons/apps/perch_members/runtime.php
@@ -323,6 +323,30 @@ function perch_member_questionsForQuestionnaire($type) {
 
 
     }
+
+    function perch_member_questionnaire_structure($type = 'first-order')
+    {
+        $API  = new PerchAPI(1.0, 'perch_members');
+        $Questionnaires = new PerchMembers_Questionnaires($API);
+
+        return $Questionnaires->get_question_structure($type);
+    }
+
+    function perch_member_questionnaire_dependencies($type = 'first-order')
+    {
+        $structure = perch_member_questionnaire_structure($type);
+        $dependencies = [];
+
+        if (is_array($structure)) {
+            foreach ($structure as $key => $question) {
+                if (!empty($question['dependencies'])) {
+                    $dependencies[$key] = $question['dependencies'];
+                }
+            }
+        }
+
+        return $dependencies;
+    }
     function perch_member_check_questionnaire_status_for_member($memberid,$qid) {
             $API  = new PerchAPI(1.0, 'perch_members');
               $Questionnaires = new PerchMembers_Questionnaires($API);

--- a/perch/templates/forms/questionnaire.html
+++ b/perch/templates/forms/questionnaire.html
@@ -23,7 +23,7 @@
 
 
                         <div class="old_title">
-                            <h2>How old are you?</h2>
+                            <h2 class="js-question-label-age">How old are you?</h2>
 
                         </div>
 
@@ -102,7 +102,7 @@
 
                    </div>-->
                         <div class="old_title">
-                            <h2>Which ethnicity are you?</h2><br>
+                            <h2 class="js-question-label-ethnicity">Which ethnicity are you?</h2><br>
 
 
                             <h2>Healthy BMI ranges are different according to your ethnic background.</h2><br>
@@ -160,7 +160,7 @@
                  </div>-->
                 </div>
                 <form id="ethnicityForm">
-                    <label for="ethnicity-more">Please tell us which ethnicities.</label>
+                    <label for="ethnicity-more" class="js-question-label-ethnicity_more">Please tell us which ethnicities.</label>
                     <textarea id="ethnicity-more"  name="ethnicity-more" placeholder=""></textarea>
                     <p id="error-message" class="error-message">Please provide an answer before continuing.</p>
                     <div class="buttons">
@@ -186,7 +186,7 @@
 
                   </div>-->
                     <div class="old_title">
-                        <h2>What sex were you assigned at birth?</h2>
+                        <h2 class="js-question-label-gender">What sex were you assigned at birth?</h2>
                     </div>
 
 
@@ -226,15 +226,15 @@
 
                        </div>-->
                 <div class="old_title">
-                    <h2>Are you currently pregnant, trying to get pregnant, or breastfeeding?</h2>
+                    <h2 class="js-question-label-pregnancy">Are you currently pregnant, trying to get pregnant, or breastfeeding?</h2>
                 </div>
 
 
                 <div class="under">
 
                     <div class="button-group">
-                        <button id="yesBtn" onclick="setValuesForm('pregnancy','yes')" <perch:if id="pregnancy" value="yes"> class="custom_btn active" </perch:if> class="custom_btn "><span style="text-decoration: none; color: #000;" >Yes</span></button>
-                        <button id="noBtn" onclick="setValuesForm('pregnancy','no')" <perch:if id="pregnancy" value="no"> class="custom_btn active" </perch:if> class="custom_btn"><span style="text-decoration: none; color: #000;" >No</span></button>
+                        <button id="yesBtn" onclick="setValuesForm('pregnancy','yes')" <perch:if id="pregnancy" value="yes"> class="custom_btn active" </perch:if> class="custom_btn "><span data-question-option-key="pregnancy" data-question-option-value="yes" style="text-decoration: none; color: #000;" >Yes</span></button>
+                        <button id="noBtn" onclick="setValuesForm('pregnancy','no')" <perch:if id="pregnancy" value="no"> class="custom_btn active" </perch:if> class="custom_btn"><span data-question-option-key="pregnancy" data-question-option-value="no" style="text-decoration: none; color: #000;" >No</span></button>
                         <input type="hidden" name="pregnancy" id="pregnancy"  />
                         <input type="hidden" id="nextstep" name="nextstep" value="">
                     </div>
@@ -288,7 +288,7 @@
                       </div>
 
                   </div>-->
-                    <h2>What is your weight?</h2>
+                    <h2 class="js-question-label-weight">What is your weight?</h2>
                     <div class="weight-inputs">
                         <input type="text" id="weight"  required name="weight" placeholder="Kg">
                         <input type="hidden" id="weight2"  required name="weight2" placeholder="lbs">
@@ -354,7 +354,7 @@
                             </div>
 
                         </div>-->
-                    <h2>What is your height?</h2>
+                    <h2 class="js-question-label-height">What is your height?</h2>
                     <div class="weight-inputs">
                         <input type="text" id="height" name="height" required placeholder="Cm">
                         <input type="hidden" id="height2" name="height2" required placeholder="7.5"  step="0.1" min="0.5" max="12" required title="Enter your height in total inches">
@@ -409,7 +409,7 @@
 
                   </div>-->
                     <div class="old_title">
-                        <h2>Have you been diagnosed with diabetes?</h2><br>
+                        <h2 class="js-question-label-diabetes">Have you been diagnosed with diabetes?</h2><br>
 
 
                         <h2>Diabetes treatments can impact the way the medication included with our weight loss plan works.
@@ -467,7 +467,7 @@
                                <!-- <div class="progress_bar">
                                     <p class="Percent_text">14%</p><span class="bar_line"></span>
                                 </div>-->
-                                <h5>Do any of the following statements apply to you?</h5>
+                                <h5 class="js-question-label-conditions">Do any of the following statements apply to you?</h5>
                                 <h5>
                                     These conditions can lead to serious complications when losing weight or taking weight loss medications.
                                 </h5>
@@ -573,7 +573,7 @@
 
                         </div>-->
                     <div class="old_title">
-                        <h2>Was your bariatric operation in the last 6 months? </h2>
+                        <h2 class="js-question-label-bariatricoperation">Was your bariatric operation in the last 6 months? </h2>
                     </div>
 
 
@@ -581,8 +581,8 @@
 
                         <div class="button-group">
 
-                            <button id="yesBtn" onclick="setValuesForm('bariatricoperation','yes')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >Yes</span></button>
-                            <button id="noBtn" onclick="setValuesForm('bariatricoperation','no')" class="custom_btn"><span style="text-decoration: none; color: #000;" >No</span></button>
+                            <button id="yesBtn" onclick="setValuesForm('bariatricoperation','yes')"  class="custom_btn"><span data-question-option-key="bariatricoperation" data-question-option-value="yes" style="text-decoration: none; color: #000;" >Yes</span></button>
+                            <button id="noBtn" onclick="setValuesForm('bariatricoperation','no')" class="custom_btn"><span data-question-option-key="bariatricoperation" data-question-option-value="no" style="text-decoration: none; color: #000;" >No</span></button>
                             <input type="hidden" id="bariatricoperation" name="bariatricoperation" value="">
 
                             <input type="hidden" id="nextstep" name="nextstep" value="">
@@ -636,7 +636,7 @@
                     </div>-->
                 </div>
                 <form id="ethnicityForm">
-                    <label for="more_pancreatitis">Please tell us more about your health condition and how you manage it.</label>
+                    <label for="more_pancreatitis" class="js-question-label-more_pancreatitis">Please tell us more about your health condition and how you manage it.</label>
                     <textarea id="more_pancreatitis" required name="more_pancreatitis" placeholder=""></textarea>
                     <p id="error-message" class="error-message">Please provide an answer before continuing.</p>
                     <div class="buttons">
@@ -664,7 +664,7 @@
                  </div>-->
                 </div>
                 <form id="thyroidoperation">
-                    <label for="thyroidoperation">Please tell us further details on the thyroid surgery you had, the outcome of the surgery and any ongoing monitoring</label>
+                    <label for="thyroidoperation" class="js-question-label-thyroidoperation">Please tell us further details on the thyroid surgery you had, the outcome of the surgery and any ongoing monitoring</label>
                     <textarea id="thyroidoperation" required name="thyroidoperation" placeholder=""></textarea>
                     <p id="error-message" class="error-message">Please provide an answer before continuing.</p>
                     <div class="buttons">
@@ -694,7 +694,7 @@
                  </div>-->
                 </div>
                 <form id="ethnicityForm">
-                    <label for="more_conditions">Please tell us more about your health condition and how you manage it.</label>
+                    <label for="more_conditions" class="js-question-label-more_conditions">Please tell us more about your health condition and how you manage it.</label>
                     <textarea id="more_conditions" required name="more_conditions" placeholder=""></textarea>
                     <p id="error-message" class="error-message">Please provide an answer before continuing.</p>
                     <div class="buttons">
@@ -720,7 +720,7 @@
                                <!-- <div class="progress_bar">
                                     <p class="Percent_text">20%</p><span class="bar_line"></span>
                                 </div>-->
-                                <h5>Do any of the following statements apply to you?</h5>
+                                <h5 class="js-question-label-conditions2">Do any of the following statements apply to you?</h5>
                                 <h5>
                                     These conditions are often weight related and may be improved as a result of losing weight.
                                 </h5>
@@ -825,7 +825,7 @@
 
                   </div>-->
                     <div class="old_title">
-                        <h2>Do you have any other medical conditions?</h2>
+                        <h2 class="js-question-label-medical_conditions">Do you have any other medical conditions?</h2>
                         <br>
                         <h2>Our clinicians need to know your full medical history to make sure our weight loss plan is safe for you. </h2>
                     </div>
@@ -834,8 +834,8 @@
                     <div class="unde">
 
                         <div class="button-group">
-                            <button id="yesBtn" onclick="setValuesForm('medical_conditions','yes')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >Yes</span></button>
-                            <button id="noBtn" onclick="setValuesForm('medical_conditions','no')" class="custom_btn"><span style="text-decoration: none; color: #000;" >No</span></button>
+                            <button id="yesBtn" onclick="setValuesForm('medical_conditions','yes')"  class="custom_btn"><span data-question-option-key="medical_conditions" data-question-option-value="yes" style="text-decoration: none; color: #000;" >Yes</span></button>
+                            <button id="noBtn" onclick="setValuesForm('medical_conditions','no')" class="custom_btn"><span data-question-option-key="medical_conditions" data-question-option-value="no" style="text-decoration: none; color: #000;" >No</span></button>
 
                             <input type="hidden" id="medical_conditions" name="medical_conditions" value="">
 
@@ -868,7 +868,7 @@
                                <!-- <div class="progress_bar">
                                     <p class="Percent_text">26%</p><span class="bar_line"></span>
                                 </div>-->
-                                <h5>
+                                <h5 class="js-question-label-medications">
                                     Have you ever taken any of the following medications to help you lose weight?
                                 </h5>
                             </div>
@@ -943,7 +943,7 @@
                        </div>
 
                    </div>-->
-                    <h2>What was your weight in kg/st-lbs before starting <span id="medication">the weight loss medication</span>?</h2>
+                    <h2 class="js-question-label-weight_wegovy">What was your weight in kg/st-lbs before starting <span id="medication">the weight loss medication</span>?</h2>
                     <div class="weight-inputs">
                         <input type="text" name="weight-wegovy" id="weight-wegovy" placeholder="Kg">
                         <input type="hidden" id="weight2-wegovy" required name="weight2-wegovy" placeholder="lbs"/>
@@ -1027,7 +1027,7 @@
 
 
                     <div class="old_title">
-                        <h2>When was your last dose of <span id="medication">the weight loss medication</span>?</h2>
+                        <h2 class="js-question-label-dose_wegovy">When was your last dose of <span id="medication">the weight loss medication</span>?</h2>
                     </div>
 
 
@@ -1083,7 +1083,7 @@
 
                  </div>-->
                     <div class="old_title">
-                        <h2>What dose of <span id="medication">the weight loss medication</span> were you prescribed most recently?</h2><br>
+                        <h2 class="js-question-label-recently_dose_wegovy">What dose of <span id="medication">the weight loss medication</span> were you prescribed most recently?</h2><br>
 
 
                     </div>
@@ -1141,7 +1141,7 @@
 
                   </div>-->
                     <div class="old_title">
-                        <h2>If you want to continue with <span id="medication">the weight loss medication</span>, what dose would you like to continue with? </h2><br>
+                        <h2 class="js-question-label-continue_dose_wegovy">If you want to continue with <span id="medication">the weight loss medication</span>, what dose would you like to continue with? </h2><br>
 
 
                         <p style="font-weight: 500;" > <strong>A</strong> clinician will review your answers and select your dosage as appropriate. Price varies by dosage. </p>
@@ -1196,15 +1196,15 @@
 
                   </div>-->
                     <div class="old_title">
-                        <h2>Have you experienced any side effects with <span id="medication">the weight loss medication</span>? </h2>
+                        <h2 class="js-question-label-effects_with_wegovy">Have you experienced any side effects with <span id="medication">the weight loss medication</span>? </h2>
                     </div>
 
 
                     <div class="unde">
 
                         <div class="button-group">
-                            <button id="yesBtn" onclick="setValuesForm('effects_with_wegovy','yes')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >Yes</span></button>
-                            <button id="noBtn" onclick="setValuesForm('effects_with_wegovy','no')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >No</span></button>
+                            <button id="yesBtn" onclick="setValuesForm('effects_with_wegovy','yes')"  class="custom_btn"><span data-question-option-key="effects_with_wegovy" data-question-option-value="yes" style="text-decoration: none; color: #000;" >Yes</span></button>
+                            <button id="noBtn" onclick="setValuesForm('effects_with_wegovy','no')"  class="custom_btn"><span data-question-option-key="effects_with_wegovy" data-question-option-value="no" style="text-decoration: none; color: #000;" >No</span></button>
                             <input type="hidden" id="nextstep" name="nextstep" value="">
                             <input type="hidden" id="effects_with_wegovy" name="effects_with_wegovy" value="">
 
@@ -1236,7 +1236,7 @@
                               <!--  <div class="progress_bar">
                                     <p class="Percent_text">95%</p><span class="bar_line"></span>
                                 </div>-->
-                                <h5>
+                                <h5 class="js-question-label-medication_allergies">
                                     Do you currently take any other medication or have any allergies? This includes prescribed medication, over-the-counter medication, and supplements. Select all that apply to you.
                                 </h5>
 
@@ -1305,7 +1305,7 @@
                    </div>-->
                 </div>
                 <form id="ethnicityForm">
-                    <label for="other_medical_conditions">Please list any other medical conditions you have. <br> <br> Our clinicians need to know your full medical history to make sure our weight loss plan is safe for you.</label>
+                    <label for="other_medical_conditions" class="js-question-label-other_medical_conditions">Please list any other medical conditions you have. <br> <br> Our clinicians need to know your full medical history to make sure our weight loss plan is safe for you.</label>
                     <textarea id="other_medical_conditions" required name="other_medical_conditions" placeholder="My health conditions are..."></textarea>
                     <p id="error-message" class="error-message">Please provide an answer before continuing.</p>
                     <div class="buttons">
@@ -1334,7 +1334,7 @@
                    </div>-->
                 </div>
                 <form id="ethnicityForm">
-                    <label for="other_medical_conditions">Please list any other medical conditions you have. <br> <br> Our clinicians need to know your full medical history to make sure our weight loss plan is safe for you.</label>
+                    <label for="other_medical_conditions" class="js-question-label-other_medical_conditions">Please list any other medical conditions you have. <br> <br> Our clinicians need to know your full medical history to make sure our weight loss plan is safe for you.</label>
                     <textarea id="other_medical_conditions" required name="other_medical_conditions" placeholder="My health conditions are..."></textarea>
                     <p id="error-message" class="error-message">Please provide an answer before continuing.</p>
                     <div class="buttons">
@@ -1364,7 +1364,7 @@
                   </div>-->
                 </div>
                 <form id="ethnicityForm">
-                    <label for="wegovy_side_effects">Please tell us as much as you can about your side effects - the type, duration, severity and whether they have resolved.</label>
+                    <label for="wegovy_side_effects" class="js-question-label-wegovy_side_effects">Please tell us as much as you can about your side effects - the type, duration, severity and whether they have resolved.</label>
                     <textarea id="wegovy_side_effects" required name="wegovy_side_effects" placeholder=""></textarea>
                     <p id="error-message" class="error-message">Please provide an answer before continuing.</p>
                     <div class="buttons">
@@ -1394,7 +1394,7 @@
 
                    </div>-->
                     <div class="old_title">
-                        <h2>Would you like your GP to be informed of this consultation?</h2><br>
+                        <h2 class="js-question-label-gp_informed">Would you like your GP to be informed of this consultation?</h2><br>
 
                         <p style="font-weight: 600;" >To ensure we provide the best and safest service for you, we strongly encourage you to share your GP details so we can inform them about your treatment. If you are aware of your GP practice's email address, please enter them on the next screen.</p>
                     </div>
@@ -1403,8 +1403,8 @@
                     <div class="unde">
 
                         <div class="button-group">
-                            <button id="yesBtn" onclick="setValuesForm('gp_informed','yes')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >Yes</span></button>
-                            <button id="noBtn" onclick="setValuesForm('gp_informed','no')" class="custom_btn"><span style="text-decoration: none; color: #000;" >No</span></button>
+                            <button id="yesBtn" onclick="setValuesForm('gp_informed','yes')"  class="custom_btn"><span data-question-option-key="gp_informed" data-question-option-value="yes" style="text-decoration: none; color: #000;" >Yes</span></button>
+                            <button id="noBtn" onclick="setValuesForm('gp_informed','no')" class="custom_btn"><span data-question-option-key="gp_informed" data-question-option-value="no" style="text-decoration: none; color: #000;" >No</span></button>
                             <input type="hidden" id="nextstep" name="nextstep" value="">
                             <input type="hidden" id="gp_informed" name="gp_informed" value="">
 
@@ -1438,7 +1438,7 @@
                        </div>
 
                    </div>-->
-                    <h2>Please enter your GP's email address</h2>
+                    <h2 class="js-question-label-gp_email_address">Please enter your GP's email address</h2>
                     <div class="weight-inputs">
                         <input type="text" id="GP_email_address"  name="GP_email_address" placeholder="GP’s e-mail address" style="width: 100%;" >
 
@@ -1476,7 +1476,7 @@
                       </div>
 
                   </div>-->
-                    <h2>Get access to special offers</h2>
+                    <h2 class="js-question-label-access_special_offers">Get access to special offers</h2>
                     <p style="font-weight: 600;" >Take the first step towards improving your metabolic health. You'll receive personalised health insights and exclusive monthly offers available only to Get Weight Loss members.</p>
                     <div class="weight-inputs">
                         <input type="text" id="email_address" name="email_address" placeholder="Email address (optional)" style="width: 100%;" >
@@ -1510,6 +1510,134 @@
 
 
 
+    <script type="application/json" class="js-questionnaire-structure"><perch:forms id="questionnaire_structure_json" encode="false" /></script>
+    <perch:if exists="questionnaire_dependencies_json">
+        <script type="application/json" class="js-questionnaire-dependencies"><perch:forms id="questionnaire_dependencies_json" encode="false" /></script>
+    </perch:if>
+    <script>
+        (function () {
+            var scripts = document.querySelectorAll('.js-questionnaire-structure');
+            if (!scripts.length) {
+                return;
+            }
+
+            function slugify(value) {
+                return (value || '').toString().trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+            }
+
+            function parseJSON(el) {
+                try {
+                    return JSON.parse(el.textContent || el.innerText || 'null');
+                } catch (e) {
+                    return null;
+                }
+            }
+
+            function cssEscape(val) {
+                return (val || '').toString().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+            }
+
+            scripts.forEach(function (script) {
+                var structure = parseJSON(script);
+                if (!structure) {
+                    return;
+                }
+
+                var form = script.closest('form') || document;
+
+                Object.keys(structure).forEach(function (key) {
+                    var question = structure[key];
+                    var questionSlug = slugify(key);
+                    var labelNodes = form.querySelectorAll('.js-question-label-' + questionSlug);
+
+                    labelNodes.forEach(function (node) {
+                        node.textContent = question.label;
+                    });
+
+                    if (!question.options || typeof question.options !== 'object') {
+                        return;
+                    }
+
+                    Object.keys(question.options).forEach(function (optionKey) {
+                        var optionValue = question.options[optionKey];
+                        var optionLabel = optionValue;
+
+                        if (optionValue && typeof optionValue === 'object') {
+                            if (optionValue.label) {
+                                optionLabel = optionValue.label;
+                            } else if (optionValue.title) {
+                                optionLabel = optionValue.title;
+                            } else if (optionValue.value) {
+                                optionLabel = optionValue.value;
+                            }
+                        }
+
+                        var value = optionKey;
+                        var selectorNames = [];
+                        if (question.name) {
+                            selectorNames.push(question.name);
+                            if (question.name.slice(-2) === '[]') {
+                                selectorNames.push(question.name.slice(0, -2) + '[]');
+                            }
+                        }
+
+                        selectorNames.push(key);
+                        if (key.slice(-2) === '[]') {
+                            selectorNames.push(key.slice(0, -2) + '[]');
+                        }
+
+                        var inputs = [];
+                        selectorNames.forEach(function (name) {
+                            var escapedName = cssEscape(name);
+                            var escapedValue = cssEscape(value);
+                            var found = form.querySelectorAll('input[name="' + escapedName + '"][value="' + escapedValue + '"]');
+                            found.forEach(function (input) {
+                                inputs.push(input);
+                            });
+                        });
+
+                        inputs.forEach(function (input) {
+                            var target = null;
+
+                            if (input.id) {
+                                target = form.querySelector('label[for="' + cssEscape(input.id) + '"]');
+                            }
+
+                            if (!target && input.parentElement) {
+                                target = input.parentElement.querySelector('label');
+                            }
+
+                            if (!target && input.parentElement) {
+                                target = input.parentElement.querySelector('.box_text');
+                            }
+
+                            if (!target && input.nextElementSibling && input.nextElementSibling.tagName === 'SPAN') {
+                                target = input.nextElementSibling;
+                            }
+
+                            if (target) {
+                                target.textContent = optionLabel;
+                            }
+                        });
+
+                        var optionSlug = slugify(optionKey);
+                        var buttonTargets = form.querySelectorAll('[data-question-option-key="' + questionSlug + '"][data-question-option-value="' + optionSlug + '"]');
+                        buttonTargets.forEach(function (node) {
+                            node.textContent = optionLabel;
+                        });
+                    });
+                });
+
+                var dependencyScript = form.querySelector('.js-questionnaire-dependencies');
+                if (dependencyScript) {
+                    var dependencies = parseJSON(dependencyScript);
+                    if (dependencies) {
+                        form.dataset.questionnaireDependencies = JSON.stringify(dependencies);
+                    }
+                }
+            });
+        })();
+    </script>
 </perch:form>
 <style>
     .custom_btn.active {

--- a/perch/templates/forms/reorder-questionnaire.html
+++ b/perch/templates/forms/reorder-questionnaire.html
@@ -10,7 +10,7 @@
                       </div>
 
                   </div>-->
-                    <h2>What is your current weight?</h2>
+                    <h2 class="js-question-label-weight">What is your current weight?</h2>
                     <div class="weight-inputs">
                         <input type="text" id="weight"  required name="weight" placeholder="Kg">
                         <input type="hidden" id="weight2"  required name="weight2" placeholder="lbs">
@@ -66,15 +66,15 @@
 
                   </div>-->
                     <div class="old_title">
-                        <h2>Have you experienced any side effects whilst taking the medication? </h2>
+                        <h2 class="js-question-label-side_effects">Have you experienced any side effects whilst taking the medication? </h2>
                     </div>
 
 
                     <div class="unde">
 
                         <div class="button-group">
-                            <button id="yesBtn" onclick="setValuesreorderForm('side_effects','yes')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >Yes</span></button>
-                            <button id="noBtn" onclick="setValuesreorderForm('side_effects','no')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >No</span></button>
+                            <button id="yesBtn" onclick="setValuesreorderForm('side_effects','yes')"  class="custom_btn"><span data-question-option-key="side_effects" data-question-option-value="yes" style="text-decoration: none; color: #000;" >Yes</span></button>
+                            <button id="noBtn" onclick="setValuesreorderForm('side_effects','no')"  class="custom_btn"><span data-question-option-key="side_effects" data-question-option-value="no" style="text-decoration: none; color: #000;" >No</span></button>
                             <input type="hidden" id="nextstep" name="nextstep" value="more_side_effects">
                             <input type="hidden" id="side_effects" name="more_side_effects" value="">
 
@@ -107,7 +107,7 @@
                   </div>-->
                 </div>
                 <form id="ethnicityForm">
-                    <label for="more_side_effects">Please tell us as much as you can about your side effects - the type, duration, severity and whether they have resolved.</label>
+                    <label for="more_side_effects" class="js-question-label-more_side_effects">Please tell us as much as you can about your side effects - the type, duration, severity and whether they have resolved.</label>
                     <textarea id="more_side_effects" required name="more_side_effects" placeholder=""></textarea>
                     <p id="error-message" class="error-message">Please provide an answer before continuing.</p>
                     <div class="buttons">
@@ -136,15 +136,15 @@
 
                   </div>-->
                     <div class="old_title">
-                        <h2>Have you started taking any additional medication? </h2>
+                        <h2 class="js-question-label-additional_medication">Have you started taking any additional medication? </h2>
                     </div>
 
 
                     <div class="unde">
 
                         <div class="button-group">
-                            <button id="yesBtn" onclick="setValuesreorderForm('additional-medication','yes')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >Yes</span></button>
-                            <button id="noBtn" onclick="setValuesreorderForm('additional-medication','no')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >No</span></button>
+                            <button id="yesBtn" onclick="setValuesreorderForm('additional-medication','yes')"  class="custom_btn"><span data-question-option-key="additional_medication" data-question-option-value="yes" style="text-decoration: none; color: #000;" >Yes</span></button>
+                            <button id="noBtn" onclick="setValuesreorderForm('additional-medication','no')"  class="custom_btn"><span data-question-option-key="additional_medication" data-question-option-value="no" style="text-decoration: none; color: #000;" >No</span></button>
                             <input type="hidden" id="nextstep" name="nextstep" value="list_additional_medication">
                             <input type="hidden" id="additional-medication" name="additional-medication" value="">
 
@@ -177,7 +177,7 @@
                   </div>-->
                 </div>
                 <form id="ethnicityForm">
-                    <label for="list_additional_medication">Please tell us as much as you can about your side effects - the type, duration, severity and whether they have resolved.</label>
+                    <label for="list_additional_medication" class="js-question-label-list_additional_medication">Please tell us as much as you can about your side effects - the type, duration, severity and whether they have resolved.</label>
                     <textarea id="list_additional_medication" required name="list_additional_medication" placeholder=""></textarea>
                     <p id="error-message" class="error-message">Please provide an answer before continuing.</p>
                     <div class="buttons">
@@ -206,15 +206,15 @@
 
                   </div>-->
                     <div class="old_title">
-                        <h2>Are you happy with your monthly weight loss?</h2>
+                        <h2 class="js-question-label-rate_current_experience">Are you happy with your monthly weight loss?</h2>
                     </div>
 
 
                     <div class="unde">
 
                         <div class="button-group">
-                            <button id="yesBtn" onclick="setValuesreorderForm('rate_current_experience','yes')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >Yes</span></button>
-                            <button id="noBtn" onclick="setValuesreorderForm('rate_current_experience','no')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >No</span></button>
+                            <button id="yesBtn" onclick="setValuesreorderForm('rate_current_experience','yes')"  class="custom_btn"><span data-question-option-key="rate_current_experience" data-question-option-value="yes" style="text-decoration: none; color: #000;" >Yes</span></button>
+                            <button id="noBtn" onclick="setValuesreorderForm('rate_current_experience','no')"  class="custom_btn"><span data-question-option-key="rate_current_experience" data-question-option-value="no" style="text-decoration: none; color: #000;" >No</span></button>
                             <input type="hidden" id="nextstep" name="nextstep" value="contact">
                             <input type="hidden" id="rate_current_experience" name="rate_current_experience" value="">
 
@@ -247,7 +247,7 @@
                   </div>-->
                 </div>
                 <form id="ethnicityForm">
-                    <label for="no_happy_reasons">Please tell us as much as you can about the reasons you are not happy with your monthly weight loss.</label>
+                    <label for="no_happy_reasons" class="js-question-label-no_happy_reasons">Please tell us as much as you can about the reasons you are not happy with your monthly weight loss.</label>
                     <textarea id="no_happy_reasons" required name="no_happy_reasons" placeholder=""></textarea>
                     <p id="error-message" class="error-message">Please provide an answer before continuing.</p>
                     <div class="buttons">
@@ -277,15 +277,15 @@
 
                   </div>-->
                     <div class="old_title">
-                        <h2>Would you like to chat with someone?</h2>
+                        <h2 class="js-question-label-chat_with_us">Would you like to chat with someone?</h2>
                     </div>
 
 
                     <div class="unde">
 
                         <div class="button-group">
-                            <button id="yesBtn" onclick="setValuesreorderForm('chat_with_us','yes')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >Yes</span></button>
-                            <button id="noBtn" onclick="setValuesreorderForm('chat_with_us','no')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >No</span></button>
+                            <button id="yesBtn" onclick="setValuesreorderForm('chat_with_us','yes')"  class="custom_btn"><span data-question-option-key="chat_with_us" data-question-option-value="yes" style="text-decoration: none; color: #000;" >Yes</span></button>
+                            <button id="noBtn" onclick="setValuesreorderForm('chat_with_us','no')"  class="custom_btn"><span data-question-option-key="chat_with_us" data-question-option-value="no" style="text-decoration: none; color: #000;" >No</span></button>
                             <input type="hidden" id="nextstep" name="nextstep" value="contact">
                             <input type="hidden" id="chat_with_us" name="chat_with_us" value="">
 
@@ -318,7 +318,7 @@
 
                   </div>-->
                 </div>
-                <h2>Please enter your  email address</h2>
+                <h2 class="js-question-label-email_address">Please enter your  email address</h2>
                 <div class="weight-inputs">
                     <input type="text" id="email_address"  name="email_address" placeholder="e-mail address" style="width: 100%;" >
 
@@ -343,4 +343,132 @@
 
     </perch:if>
 
+    <script type="application/json" class="js-questionnaire-structure"><perch:forms id="questionnaire_structure_json" encode="false" /></script>
+    <perch:if exists="questionnaire_dependencies_json">
+        <script type="application/json" class="js-questionnaire-dependencies"><perch:forms id="questionnaire_dependencies_json" encode="false" /></script>
+    </perch:if>
+    <script>
+        (function () {
+            var scripts = document.querySelectorAll('.js-questionnaire-structure');
+            if (!scripts.length) {
+                return;
+            }
+
+            function slugify(value) {
+                return (value || '').toString().trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+            }
+
+            function parseJSON(el) {
+                try {
+                    return JSON.parse(el.textContent || el.innerText || 'null');
+                } catch (e) {
+                    return null;
+                }
+            }
+
+            function cssEscape(val) {
+                return (val || '').toString().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+            }
+
+            scripts.forEach(function (script) {
+                var structure = parseJSON(script);
+                if (!structure) {
+                    return;
+                }
+
+                var form = script.closest('form') || document;
+
+                Object.keys(structure).forEach(function (key) {
+                    var question = structure[key];
+                    var questionSlug = slugify(key);
+                    var labelNodes = form.querySelectorAll('.js-question-label-' + questionSlug);
+
+                    labelNodes.forEach(function (node) {
+                        node.textContent = question.label;
+                    });
+
+                    if (!question.options || typeof question.options !== 'object') {
+                        return;
+                    }
+
+                    Object.keys(question.options).forEach(function (optionKey) {
+                        var optionValue = question.options[optionKey];
+                        var optionLabel = optionValue;
+
+                        if (optionValue && typeof optionValue === 'object') {
+                            if (optionValue.label) {
+                                optionLabel = optionValue.label;
+                            } else if (optionValue.title) {
+                                optionLabel = optionValue.title;
+                            } else if (optionValue.value) {
+                                optionLabel = optionValue.value;
+                            }
+                        }
+
+                        var value = optionKey;
+                        var selectorNames = [];
+                        if (question.name) {
+                            selectorNames.push(question.name);
+                            if (question.name.slice(-2) === '[]') {
+                                selectorNames.push(question.name.slice(0, -2) + '[]');
+                            }
+                        }
+
+                        selectorNames.push(key);
+                        if (key.slice(-2) === '[]') {
+                            selectorNames.push(key.slice(0, -2) + '[]');
+                        }
+
+                        var inputs = [];
+                        selectorNames.forEach(function (name) {
+                            var escapedName = cssEscape(name);
+                            var escapedValue = cssEscape(value);
+                            var found = form.querySelectorAll('input[name="' + escapedName + '"][value="' + escapedValue + '"]');
+                            found.forEach(function (input) {
+                                inputs.push(input);
+                            });
+                        });
+
+                        inputs.forEach(function (input) {
+                            var target = null;
+
+                            if (input.id) {
+                                target = form.querySelector('label[for="' + cssEscape(input.id) + '"]');
+                            }
+
+                            if (!target && input.parentElement) {
+                                target = input.parentElement.querySelector('label');
+                            }
+
+                            if (!target && input.parentElement) {
+                                target = input.parentElement.querySelector('.box_text');
+                            }
+
+                            if (!target && input.nextElementSibling && input.nextElementSibling.tagName === 'SPAN') {
+                                target = input.nextElementSibling;
+                            }
+
+                            if (target) {
+                                target.textContent = optionLabel;
+                            }
+                        });
+
+                        var optionSlug = slugify(optionKey);
+                        var buttonTargets = form.querySelectorAll('[data-question-option-key="' + questionSlug + '"][data-question-option-value="' + optionSlug + '"]');
+                        buttonTargets.forEach(function (node) {
+                            node.textContent = optionLabel;
+                        });
+                    });
+                });
+
+                var dependencyScript = form.querySelector('.js-questionnaire-dependencies');
+                if (dependencyScript) {
+                    var dependencies = parseJSON(dependencyScript);
+                    if (dependencies) {
+                        form.dataset.questionnaireDependencies = JSON.stringify(dependencies);
+                    }
+                }
+            });
+        })();
+    </script>
 </perch:form>

--- a/perch/templates/pages/client/reorder-questionnaire.php
+++ b/perch/templates/pages/client/reorder-questionnaire.php
@@ -133,6 +133,16 @@ if(isset( $_GET["step"])){
 PerchSystem::set_var('step', $_GET["step"]);
 }
 
+$reorder_structure = perch_member_questionnaire_structure('re-order');
+if (is_array($reorder_structure) && PerchUtil::count($reorder_structure)) {
+    PerchSystem::set_var('questionnaire_structure_json', PerchUtil::json_safe_encode($reorder_structure));
+
+    $reorder_dependencies = perch_member_questionnaire_dependencies('re-order');
+    if (is_array($reorder_dependencies) && PerchUtil::count($reorder_dependencies)) {
+        PerchSystem::set_var('questionnaire_dependencies_json', PerchUtil::json_safe_encode($reorder_dependencies));
+    }
+}
+
  perch_form('reorder-questionnaire.html');
 
             ?>

--- a/perch/templates/pages/getStarted/questionnaire.php
+++ b/perch/templates/pages/getStarted/questionnaire.php
@@ -357,6 +357,16 @@ $back_links['conditions']="/get-started/questionnaire?step=more_pancreatitis";
 
 $back_link = $back_links[$_GET["step"]] ?? '/get-started';
 
+$questionnaire_structure = perch_member_questionnaire_structure('first-order');
+if (is_array($questionnaire_structure) && PerchUtil::count($questionnaire_structure)) {
+    PerchSystem::set_var('questionnaire_structure_json', PerchUtil::json_safe_encode($questionnaire_structure));
+
+    $questionnaire_dependencies = perch_member_questionnaire_dependencies('first-order');
+    if (is_array($questionnaire_dependencies) && PerchUtil::count($questionnaire_dependencies)) {
+        PerchSystem::set_var('questionnaire_dependencies_json', PerchUtil::json_safe_encode($questionnaire_dependencies));
+    }
+}
+
 PerchSystem::set_var('previousPage', $back_link);
 PerchSystem::set_var('answers', $_SESSION['questionnaire']);
  PerchSystem::set_vars($_SESSION['questionnaire']);


### PR DESCRIPTION
## Summary
- extend questionnaire question definitions to include field name, step, and dependency metadata and seed the database with the expanded data set
- update questionnaire loading logic to read steps and dependencies from the database, ensure schema columns exist, and expose aliases/options for front-end consumers
- drive the review page from the shared questionnaire structure so question labels and answer values are rendered dynamically

## Testing
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
- php -l perch/addons/apps/perch_members/import_questionnaire_questions.php
- php -l perch/addons/apps/perch_members/activate.php
- php -l perch/addons/apps/perch_members/questionnaire_default_questions.php
- php -l perch/templates/pages/getStarted/review-questionnaire.php

------
https://chatgpt.com/codex/tasks/task_b_68cd4cd31c008324baabd6e688d88722