### PR TITLE
Improve review questionnaire answer rendering

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
@@ -151,6 +151,8 @@ class PerchMembers_Questionnaires extends PerchAPI_Factory
                 'options'      => $opts,
                 'step'         => $step,
                 'dependencies' => $deps,
+                'sort'         => isset($row['sort']) ? (int)$row['sort'] : null,
+                'question_id'  => isset($row['questionID']) ? (int)$row['questionID'] : null,
             ];
 
             $aliases = $this->expand_aliases($row['questionKey'], $row['type']);
@@ -290,19 +292,36 @@ class PerchMembers_Questionnaires extends PerchAPI_Factory
         if (PerchUtil::count($questions)) {
             foreach ($questions as $key => $question) {
                 $structure[$key] = [
-                    'key'         => $key,
-                    'label'       => $question['label'],
-                    'type'        => $question['type'],
-                    'name'        => $question['name'] ?? $key,
-                    'options'     => isset($question['options']) && is_array($question['options']) ? $question['options'] : [],
-                    'step'        => $question['step'] ?? $key,
-                    'dependencies'=> isset($question['dependencies']) && is_array($question['dependencies']) ? $question['dependencies'] : [],
+                    'key'          => $key,
+                    'label'        => $question['label'],
+                    'type'         => $question['type'],
+                    'name'         => $question['name'] ?? $key,
+                    'options'      => isset($question['options']) && is_array($question['options']) ? $question['options'] : [],
+                    'step'         => $question['step'] ?? $key,
+                    'dependencies' => isset($question['dependencies']) && is_array($question['dependencies']) ? $question['dependencies'] : [],
+                    'sort'         => isset($question['sort']) ? (int)$question['sort'] : null,
+                    'question_id'  => isset($question['question_id']) ? (int)$question['question_id'] : null,
                 ];
 
                 if (!empty($question['aliases'])) {
                     $structure[$key]['aliases'] = $question['aliases'];
                 }
             }
+        }
+
+        if (PerchUtil::count($structure)) {
+            uasort($structure, function ($a, $b) {
+                $sortA = isset($a['sort']) ? (int)$a['sort'] : PHP_INT_MAX;
+                $sortB = isset($b['sort']) ? (int)$b['sort'] : PHP_INT_MAX;
+
+                if ($sortA === $sortB) {
+                    $keyA = isset($a['key']) ? (string)$a['key'] : '';
+                    $keyB = isset($b['key']) ? (string)$b['key'] : '';
+                    return strcmp($keyA, $keyB);
+                }
+
+                return $sortA <=> $sortB;
+            });
         }
 
         return $structure;

--- a/perch/templates/forms/questionnaire.html
+++ b/perch/templates/forms/questionnaire.html
@@ -1,4 +1,4 @@
-<perch:form id="questionnaire" method="POST" app="perch_forms" action="/get-started/questionnaire" >
+<perch:form id="questionnaire" method="POST" app="perch_forms" action="/get-started/questionnaire" data-questionnaire-form data-current-step="<perch:forms id="questionnaire_current_step" encode="attr" />" data-default-step="<perch:forms id="questionnaire_default_step" encode="attr" />" data-final-step="plans">
  <!--  <a href="/get-started/questionnaire?step=startagain" style="text-decoration: none;color: #000;" >Start again </a>-->
 
     <perch:if id="step" value="howold">
@@ -1514,18 +1514,28 @@
     <perch:if exists="questionnaire_dependencies_json">
         <script type="application/json" class="js-questionnaire-dependencies"><perch:forms id="questionnaire_dependencies_json" encode="false" /></script>
     </perch:if>
+    <perch:if exists="questionnaire_steps_json">
+        <script type="application/json" class="js-questionnaire-steps"><perch:forms id="questionnaire_steps_json" encode="false" /></script>
+    </perch:if>
+    <perch:if exists="questionnaire_answers_json">
+        <script type="application/json" class="js-questionnaire-answers"><perch:forms id="questionnaire_answers_json" encode="false" /></script>
+    </perch:if>
     <script>
         (function () {
-            var scripts = document.querySelectorAll('.js-questionnaire-structure');
-            if (!scripts.length) {
+            var form = document.querySelector('[data-questionnaire-form]');
+            if (!form) {
                 return;
             }
 
-            function slugify(value) {
-                return (value || '').toString().trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+            var structureScript = form.querySelector('.js-questionnaire-structure');
+            if (!structureScript) {
+                return;
             }
 
             function parseJSON(el) {
+                if (!el) {
+                    return null;
+                }
                 try {
                     return JSON.parse(el.textContent || el.innerText || 'null');
                 } catch (e) {
@@ -1533,24 +1543,170 @@
                 }
             }
 
-            function cssEscape(val) {
-                return (val || '').toString().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+            function slugify(value) {
+                return (value || '').toString().trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
             }
 
-            scripts.forEach(function (script) {
-                var structure = parseJSON(script);
-                if (!structure) {
+            function cssEscape(value) {
+                return (value || '').toString().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+            }
+
+            var structure = parseJSON(structureScript) || {};
+            var dependencyScript = form.querySelector('.js-questionnaire-dependencies');
+            var dependencies = dependencyScript ? parseJSON(dependencyScript) || {} : {};
+            var stepsScript = form.querySelector('.js-questionnaire-steps');
+            var providedSteps = stepsScript ? parseJSON(stepsScript) || {} : {};
+            var storedAnswersScript = form.querySelector('.js-questionnaire-answers');
+            var storedAnswers = storedAnswersScript ? parseJSON(storedAnswersScript) || {} : {};
+
+            var currentStep = form.getAttribute('data-current-step') || '';
+            var defaultStep = form.getAttribute('data-default-step') || '';
+            var finalStep = form.getAttribute('data-final-step') || 'plans';
+            if (!currentStep) {
+                currentStep = defaultStep;
+            }
+
+            var stepQuestions = buildStepQuestions(structure, providedSteps);
+            var stepOrder = buildStepOrder(stepQuestions, structure);
+            var answerState = {};
+            if (storedAnswers && typeof storedAnswers === 'object') {
+                for (var storedKey in storedAnswers) {
+                    if (storedAnswers.hasOwnProperty(storedKey)) {
+                        answerState[storedKey] = storedAnswers[storedKey];
+                    }
+                }
+            }
+
+            applyQuestionLabels(form, structure);
+
+            form.addEventListener('change', function (event) {
+                var target = event.target;
+                if (!target || !target.name) {
                     return;
                 }
+                if (target.type === 'radio' || target.type === 'checkbox') {
+                    toggleActiveButtons(target.name, readValueFromInput(target));
+                }
+                updateNextStep();
+            }, true);
 
-                var form = script.closest('form') || document;
+            form.addEventListener('submit', function () {
+                updateNextStep();
+            });
 
+            window.submitForm = function () {
+                updateNextStep();
+                form.submit();
+            };
+
+            window.setValuesForm = function (questionKey, value) {
+                setHiddenValue(questionKey, value);
+                toggleActiveButtons(questionKey, value);
+                updateNextStep();
+                form.submit();
+            };
+
+            window.setValuesreorderForm = function (questionKey, value) {
+                setHiddenValue(questionKey, value);
+                toggleActiveButtons(questionKey, value);
+                updateNextStep();
+                form.submit();
+            };
+
+            updateNextStep();
+
+            function buildStepQuestions(structure, provided) {
+                if (provided && Object.keys(provided).length) {
+                    return provided;
+                }
+
+                var steps = {};
+                var sortedKeys = sortQuestionKeys(Object.keys(structure || {}), structure);
+                sortedKeys.forEach(function (key) {
+                    var question = structure[key];
+                    if (!question) {
+                        return;
+                    }
+                    var step = question.step && question.step !== '' ? question.step : key;
+                    if (!steps[step]) {
+                        steps[step] = [];
+                    }
+                    steps[step].push(key);
+                });
+
+                Object.keys(steps).forEach(function (step) {
+                    steps[step] = sortQuestionKeys(steps[step], structure);
+                });
+
+                return steps;
+            }
+
+            function buildStepOrder(stepQuestions, structure) {
+                var steps = stepQuestions ? Object.keys(stepQuestions) : [];
+                var maxSort = (typeof Number !== 'undefined' && typeof Number.MAX_SAFE_INTEGER === 'number')
+                    ? Number.MAX_SAFE_INTEGER
+                    : Math.pow(2, 53) - 1;
+
+                function minSortForStep(stepKey) {
+                    var questions = stepQuestions[stepKey] || [];
+                    if (!questions.length) {
+                        return maxSort;
+                    }
+
+                    var min = maxSort;
+                    for (var i = 0; i < questions.length; i++) {
+                        var key = questions[i];
+                        var sortValue = getQuestionSort(structure[key]);
+                        if (sortValue < min) {
+                            min = sortValue;
+                        }
+                    }
+                    return min;
+                }
+
+                return steps.sort(function (a, b) {
+                    var sortA = minSortForStep(a);
+                    var sortB = minSortForStep(b);
+                    if (sortA === sortB) {
+                        return a.localeCompare(b);
+                    }
+                    return sortA - sortB;
+                });
+            }
+
+            function getQuestionSort(question) {
+                var maxSort = (typeof Number !== 'undefined' && typeof Number.MAX_SAFE_INTEGER === 'number')
+                    ? Number.MAX_SAFE_INTEGER
+                    : Math.pow(2, 53) - 1;
+                if (!question || typeof question.sort === 'undefined' || question.sort === null) {
+                    return maxSort;
+                }
+
+                var parsed = parseInt(question.sort, 10);
+                if (isNaN(parsed)) {
+                    return maxSort;
+                }
+                return parsed;
+            }
+
+            function sortQuestionKeys(keys, structure) {
+                var list = Array.isArray(keys) ? keys.slice() : [];
+                return list.sort(function (a, b) {
+                    var sortA = getQuestionSort(structure[a]);
+                    var sortB = getQuestionSort(structure[b]);
+                    if (sortA === sortB) {
+                        return String(a).localeCompare(String(b));
+                    }
+                    return sortA - sortB;
+                });
+            }
+
+            function applyQuestionLabels(form, structure) {
                 Object.keys(structure).forEach(function (key) {
                     var question = structure[key];
                     var questionSlug = slugify(key);
                     var labelNodes = form.querySelectorAll('.js-question-label-' + questionSlug);
-
-                    labelNodes.forEach(function (node) {
+                    Array.prototype.forEach.call(labelNodes, function (node) {
                         node.textContent = question.label;
                     });
 
@@ -1586,56 +1742,258 @@
                             selectorNames.push(key.slice(0, -2) + '[]');
                         }
 
-                        var inputs = [];
                         selectorNames.forEach(function (name) {
                             var escapedName = cssEscape(name);
                             var escapedValue = cssEscape(value);
-                            var found = form.querySelectorAll('input[name="' + escapedName + '"][value="' + escapedValue + '"]');
-                            found.forEach(function (input) {
-                                inputs.push(input);
+                            var inputs = form.querySelectorAll('input[name="' + escapedName + '"][value="' + escapedValue + '"]');
+                            Array.prototype.forEach.call(inputs, function (input) {
+                                var target = null;
+
+                                if (input.id) {
+                                    target = form.querySelector('label[for="' + cssEscape(input.id) + '"]');
+                                }
+
+                                if (!target && input.parentElement) {
+                                    target = input.parentElement.querySelector('label');
+                                }
+
+                                if (!target && input.parentElement) {
+                                    target = input.parentElement.querySelector('.box_text');
+                                }
+
+                                if (!target && input.nextElementSibling && input.nextElementSibling.tagName === 'SPAN') {
+                                    target = input.nextElementSibling;
+                                }
+
+                                if (target) {
+                                    target.textContent = optionLabel;
+                                }
                             });
-                        });
-
-                        inputs.forEach(function (input) {
-                            var target = null;
-
-                            if (input.id) {
-                                target = form.querySelector('label[for="' + cssEscape(input.id) + '"]');
-                            }
-
-                            if (!target && input.parentElement) {
-                                target = input.parentElement.querySelector('label');
-                            }
-
-                            if (!target && input.parentElement) {
-                                target = input.parentElement.querySelector('.box_text');
-                            }
-
-                            if (!target && input.nextElementSibling && input.nextElementSibling.tagName === 'SPAN') {
-                                target = input.nextElementSibling;
-                            }
-
-                            if (target) {
-                                target.textContent = optionLabel;
-                            }
                         });
 
                         var optionSlug = slugify(optionKey);
                         var buttonTargets = form.querySelectorAll('[data-question-option-key="' + questionSlug + '"][data-question-option-value="' + optionSlug + '"]');
-                        buttonTargets.forEach(function (node) {
+                        Array.prototype.forEach.call(buttonTargets, function (node) {
                             node.textContent = optionLabel;
                         });
                     });
                 });
+            }
 
-                var dependencyScript = form.querySelector('.js-questionnaire-dependencies');
-                if (dependencyScript) {
-                    var dependencies = parseJSON(dependencyScript);
-                    if (dependencies) {
-                        form.dataset.questionnaireDependencies = JSON.stringify(dependencies);
+            function updateNextStep() {
+                var fields = form.querySelectorAll('input[name="nextstep"]');
+                if (!fields.length) {
+                    return;
+                }
+                var next = computeNextStep();
+                Array.prototype.forEach.call(fields, function (field) {
+                    field.value = next || '';
+                });
+            }
+
+            function computeNextStep() {
+                var step = currentStep || stepOrder[0] || '';
+                if (!step) {
+                    return '';
+                }
+
+                var questions = stepQuestions[step] || [];
+                for (var i = 0; i < questions.length; i++) {
+                    var key = questions[i];
+                    var question = structure[key];
+                    if (!question) {
+                        continue;
+                    }
+                    var value = readAnswer(question);
+                    if (value === null || typeof value === 'undefined' || (Array.isArray(value) && !value.length)) {
+                        continue;
+                    }
+
+                    var manual = manualQuestionRouting(question, value);
+                    if (manual) {
+                        return manual;
+                    }
+
+                    var dependencyNext = dependencyRouting(question, value);
+                    if (dependencyNext) {
+                        return dependencyNext;
                     }
                 }
-            });
+
+                var manualStep = manualStepRouting(step);
+                if (manualStep) {
+                    return manualStep;
+                }
+
+                var index = stepOrder.indexOf(step);
+                if (index !== -1 && index + 1 < stepOrder.length) {
+                    return stepOrder[index + 1];
+                }
+
+                return finalStep;
+            }
+
+            function manualQuestionRouting(question, value) {
+                var name = question.name || question.key;
+                var handlers = {
+                    'age': function (val) {
+                        if (Array.isArray(val)) {
+                            val = val[0];
+                        }
+                        if (val === 'under18') {
+                            return 'under18';
+                        }
+                        if (val === '75over') {
+                            return '75over';
+                        }
+                        if (val === '18to74') {
+                            return '18to74';
+                        }
+                        return null;
+                    }
+                };
+
+                if (handlers[name]) {
+                    return handlers[name](value);
+                }
+
+                return null;
+            }
+
+            function manualStepRouting(step) {
+                return null;
+            }
+
+            function dependencyRouting(question, value) {
+                var key = question.key || question.name;
+                var questionDependencies = dependencies[key];
+                if (!questionDependencies) {
+                    return null;
+                }
+
+                var values = Array.isArray(value) ? value : [value];
+
+                for (var i = 0; i < questionDependencies.length; i++) {
+                    var dependency = questionDependencies[i];
+                    if (!dependency || !dependency.step) {
+                        continue;
+                    }
+                    var dependencyValues = dependency.values;
+                    if (typeof dependencyValues === 'undefined') {
+                        continue;
+                    }
+                    if (!Array.isArray(dependencyValues)) {
+                        dependencyValues = [dependencyValues];
+                    }
+
+                    for (var j = 0; j < values.length; j++) {
+                        if (dependencyValues.indexOf(values[j]) !== -1) {
+                            return dependency.step;
+                        }
+                    }
+                }
+
+                return null;
+            }
+
+            function readAnswer(question) {
+                var name = question.name || question.key;
+                if (!name) {
+                    return null;
+                }
+
+                var selector = '[name="' + cssEscape(name) + '"]';
+                if (question.type === 'checkbox') {
+                    var values = [];
+                    var nodes = form.querySelectorAll(selector);
+                    Array.prototype.forEach.call(nodes, function (node) {
+                        if (node.checked) {
+                            values.push(node.value);
+                        }
+                    });
+                    answerState[name] = values;
+                    return values;
+                }
+
+                if (question.type === 'radio') {
+                    var checked = form.querySelector(selector + ':checked');
+                    var radioValue = checked ? checked.value : null;
+                    answerState[name] = radioValue;
+                    return radioValue;
+                }
+
+                var input = form.querySelector(selector);
+                var inputValue = input ? input.value : null;
+                answerState[name] = inputValue;
+                return inputValue;
+            }
+
+            function setHiddenValue(questionKey, value) {
+                var field = document.getElementById(questionKey);
+                if (!field) {
+                    field = form.querySelector('[name="' + cssEscape(questionKey) + '"]');
+                }
+                if (!field) {
+                    field = form.querySelector('[name="' + cssEscape(questionKey) + '[]"]');
+                }
+                if (!field) {
+                    return;
+                }
+
+                if (field.type === 'checkbox') {
+                    var values = Array.isArray(value) ? value : [value];
+                    var nodes = form.querySelectorAll('[name="' + cssEscape(field.name) + '"]');
+                    Array.prototype.forEach.call(nodes, function (node) {
+                        node.checked = values.indexOf(node.value) !== -1;
+                    });
+                } else {
+                    field.value = value;
+                }
+
+                answerState[questionKey] = value;
+            }
+
+            function toggleActiveButtons(questionKey, value) {
+                if (!questionKey) {
+                    return;
+                }
+                var slug = slugify(questionKey);
+                var nodes = form.querySelectorAll('[data-question-option-key="' + slug + '"]');
+                if (!nodes.length) {
+                    return;
+                }
+
+                var values = Array.isArray(value) ? value.map(String) : [String(value)];
+                Array.prototype.forEach.call(nodes, function (node) {
+                    var parentButton = node.closest('button');
+                    if (!parentButton) {
+                        return;
+                    }
+                    var optionValue = node.getAttribute('data-question-option-value');
+                    if (optionValue && values.indexOf(optionValue) !== -1) {
+                        parentButton.classList.add('active');
+                    } else {
+                        parentButton.classList.remove('active');
+                    }
+                });
+            }
+
+            function readValueFromInput(input) {
+                if (input.type === 'checkbox') {
+                    var values = [];
+                    var nodes = form.querySelectorAll('[name="' + cssEscape(input.name) + '"]');
+                    Array.prototype.forEach.call(nodes, function (node) {
+                        if (node.checked) {
+                            values.push(node.value);
+                        }
+                    });
+                    return values;
+                }
+                if (input.type === 'radio') {
+                    return input.checked ? input.value : null;
+                }
+                return input.value;
+            }
         })();
     </script>
 </perch:form>

--- a/perch/templates/forms/reorder-questionnaire.html
+++ b/perch/templates/forms/reorder-questionnaire.html
@@ -1,4 +1,4 @@
-<perch:form id="questionnaire" method="POST" app="perch_forms" action="/client/questionnaire-re-order" >
+<perch:form id="questionnaire" method="POST" app="perch_forms" action="/client/questionnaire-re-order" data-questionnaire-form data-current-step="<perch:forms id="questionnaire_current_step" encode="attr" />" data-default-step="<perch:forms id="questionnaire_default_step" encode="attr" />" data-final-step="cart">
 
     <perch:if id="step" match="within" value="weight">
         <section class="how_old">
@@ -347,18 +347,28 @@
     <perch:if exists="questionnaire_dependencies_json">
         <script type="application/json" class="js-questionnaire-dependencies"><perch:forms id="questionnaire_dependencies_json" encode="false" /></script>
     </perch:if>
+    <perch:if exists="questionnaire_steps_json">
+        <script type="application/json" class="js-questionnaire-steps"><perch:forms id="questionnaire_steps_json" encode="false" /></script>
+    </perch:if>
+    <perch:if exists="questionnaire_answers_json">
+        <script type="application/json" class="js-questionnaire-answers"><perch:forms id="questionnaire_answers_json" encode="false" /></script>
+    </perch:if>
     <script>
         (function () {
-            var scripts = document.querySelectorAll('.js-questionnaire-structure');
-            if (!scripts.length) {
+            var form = document.querySelector('[data-questionnaire-form]');
+            if (!form) {
                 return;
             }
 
-            function slugify(value) {
-                return (value || '').toString().trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+            var structureScript = form.querySelector('.js-questionnaire-structure');
+            if (!structureScript) {
+                return;
             }
 
             function parseJSON(el) {
+                if (!el) {
+                    return null;
+                }
                 try {
                     return JSON.parse(el.textContent || el.innerText || 'null');
                 } catch (e) {
@@ -366,24 +376,170 @@
                 }
             }
 
-            function cssEscape(val) {
-                return (val || '').toString().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+            function slugify(value) {
+                return (value || '').toString().trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
             }
 
-            scripts.forEach(function (script) {
-                var structure = parseJSON(script);
-                if (!structure) {
+            function cssEscape(value) {
+                return (value || '').toString().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+            }
+
+            var structure = parseJSON(structureScript) || {};
+            var dependencyScript = form.querySelector('.js-questionnaire-dependencies');
+            var dependencies = dependencyScript ? parseJSON(dependencyScript) || {} : {};
+            var stepsScript = form.querySelector('.js-questionnaire-steps');
+            var providedSteps = stepsScript ? parseJSON(stepsScript) || {} : {};
+            var storedAnswersScript = form.querySelector('.js-questionnaire-answers');
+            var storedAnswers = storedAnswersScript ? parseJSON(storedAnswersScript) || {} : {};
+
+            var currentStep = form.getAttribute('data-current-step') || '';
+            var defaultStep = form.getAttribute('data-default-step') || '';
+            var finalStep = form.getAttribute('data-final-step') || 'plans';
+            if (!currentStep) {
+                currentStep = defaultStep;
+            }
+
+            var stepQuestions = buildStepQuestions(structure, providedSteps);
+            var stepOrder = buildStepOrder(stepQuestions, structure);
+            var answerState = {};
+            if (storedAnswers && typeof storedAnswers === 'object') {
+                for (var storedKey in storedAnswers) {
+                    if (storedAnswers.hasOwnProperty(storedKey)) {
+                        answerState[storedKey] = storedAnswers[storedKey];
+                    }
+                }
+            }
+
+            applyQuestionLabels(form, structure);
+
+            form.addEventListener('change', function (event) {
+                var target = event.target;
+                if (!target || !target.name) {
                     return;
                 }
+                if (target.type === 'radio' || target.type === 'checkbox') {
+                    toggleActiveButtons(target.name, readValueFromInput(target));
+                }
+                updateNextStep();
+            }, true);
 
-                var form = script.closest('form') || document;
+            form.addEventListener('submit', function () {
+                updateNextStep();
+            });
 
+            window.submitForm = function () {
+                updateNextStep();
+                form.submit();
+            };
+
+            window.setValuesForm = function (questionKey, value) {
+                setHiddenValue(questionKey, value);
+                toggleActiveButtons(questionKey, value);
+                updateNextStep();
+                form.submit();
+            };
+
+            window.setValuesreorderForm = function (questionKey, value) {
+                setHiddenValue(questionKey, value);
+                toggleActiveButtons(questionKey, value);
+                updateNextStep();
+                form.submit();
+            };
+
+            updateNextStep();
+
+            function buildStepQuestions(structure, provided) {
+                if (provided && Object.keys(provided).length) {
+                    return provided;
+                }
+
+                var steps = {};
+                var sortedKeys = sortQuestionKeys(Object.keys(structure || {}), structure);
+                sortedKeys.forEach(function (key) {
+                    var question = structure[key];
+                    if (!question) {
+                        return;
+                    }
+                    var step = question.step && question.step !== '' ? question.step : key;
+                    if (!steps[step]) {
+                        steps[step] = [];
+                    }
+                    steps[step].push(key);
+                });
+
+                Object.keys(steps).forEach(function (step) {
+                    steps[step] = sortQuestionKeys(steps[step], structure);
+                });
+
+                return steps;
+            }
+
+            function buildStepOrder(stepQuestions, structure) {
+                var steps = stepQuestions ? Object.keys(stepQuestions) : [];
+                var maxSort = (typeof Number !== 'undefined' && typeof Number.MAX_SAFE_INTEGER === 'number')
+                    ? Number.MAX_SAFE_INTEGER
+                    : Math.pow(2, 53) - 1;
+
+                function minSortForStep(stepKey) {
+                    var questions = stepQuestions[stepKey] || [];
+                    if (!questions.length) {
+                        return maxSort;
+                    }
+
+                    var min = maxSort;
+                    for (var i = 0; i < questions.length; i++) {
+                        var key = questions[i];
+                        var sortValue = getQuestionSort(structure[key]);
+                        if (sortValue < min) {
+                            min = sortValue;
+                        }
+                    }
+                    return min;
+                }
+
+                return steps.sort(function (a, b) {
+                    var sortA = minSortForStep(a);
+                    var sortB = minSortForStep(b);
+                    if (sortA === sortB) {
+                        return a.localeCompare(b);
+                    }
+                    return sortA - sortB;
+                });
+            }
+
+            function getQuestionSort(question) {
+                var maxSort = (typeof Number !== 'undefined' && typeof Number.MAX_SAFE_INTEGER === 'number')
+                    ? Number.MAX_SAFE_INTEGER
+                    : Math.pow(2, 53) - 1;
+                if (!question || typeof question.sort === 'undefined' || question.sort === null) {
+                    return maxSort;
+                }
+
+                var parsed = parseInt(question.sort, 10);
+                if (isNaN(parsed)) {
+                    return maxSort;
+                }
+                return parsed;
+            }
+
+            function sortQuestionKeys(keys, structure) {
+                var list = Array.isArray(keys) ? keys.slice() : [];
+                return list.sort(function (a, b) {
+                    var sortA = getQuestionSort(structure[a]);
+                    var sortB = getQuestionSort(structure[b]);
+                    if (sortA === sortB) {
+                        return String(a).localeCompare(String(b));
+                    }
+                    return sortA - sortB;
+                });
+            }
+
+            function applyQuestionLabels(form, structure) {
                 Object.keys(structure).forEach(function (key) {
                     var question = structure[key];
                     var questionSlug = slugify(key);
                     var labelNodes = form.querySelectorAll('.js-question-label-' + questionSlug);
-
-                    labelNodes.forEach(function (node) {
+                    Array.prototype.forEach.call(labelNodes, function (node) {
                         node.textContent = question.label;
                     });
 
@@ -419,56 +575,258 @@
                             selectorNames.push(key.slice(0, -2) + '[]');
                         }
 
-                        var inputs = [];
                         selectorNames.forEach(function (name) {
                             var escapedName = cssEscape(name);
                             var escapedValue = cssEscape(value);
-                            var found = form.querySelectorAll('input[name="' + escapedName + '"][value="' + escapedValue + '"]');
-                            found.forEach(function (input) {
-                                inputs.push(input);
+                            var inputs = form.querySelectorAll('input[name="' + escapedName + '"][value="' + escapedValue + '"]');
+                            Array.prototype.forEach.call(inputs, function (input) {
+                                var target = null;
+
+                                if (input.id) {
+                                    target = form.querySelector('label[for="' + cssEscape(input.id) + '"]');
+                                }
+
+                                if (!target && input.parentElement) {
+                                    target = input.parentElement.querySelector('label');
+                                }
+
+                                if (!target && input.parentElement) {
+                                    target = input.parentElement.querySelector('.box_text');
+                                }
+
+                                if (!target && input.nextElementSibling && input.nextElementSibling.tagName === 'SPAN') {
+                                    target = input.nextElementSibling;
+                                }
+
+                                if (target) {
+                                    target.textContent = optionLabel;
+                                }
                             });
-                        });
-
-                        inputs.forEach(function (input) {
-                            var target = null;
-
-                            if (input.id) {
-                                target = form.querySelector('label[for="' + cssEscape(input.id) + '"]');
-                            }
-
-                            if (!target && input.parentElement) {
-                                target = input.parentElement.querySelector('label');
-                            }
-
-                            if (!target && input.parentElement) {
-                                target = input.parentElement.querySelector('.box_text');
-                            }
-
-                            if (!target && input.nextElementSibling && input.nextElementSibling.tagName === 'SPAN') {
-                                target = input.nextElementSibling;
-                            }
-
-                            if (target) {
-                                target.textContent = optionLabel;
-                            }
                         });
 
                         var optionSlug = slugify(optionKey);
                         var buttonTargets = form.querySelectorAll('[data-question-option-key="' + questionSlug + '"][data-question-option-value="' + optionSlug + '"]');
-                        buttonTargets.forEach(function (node) {
+                        Array.prototype.forEach.call(buttonTargets, function (node) {
                             node.textContent = optionLabel;
                         });
                     });
                 });
+            }
 
-                var dependencyScript = form.querySelector('.js-questionnaire-dependencies');
-                if (dependencyScript) {
-                    var dependencies = parseJSON(dependencyScript);
-                    if (dependencies) {
-                        form.dataset.questionnaireDependencies = JSON.stringify(dependencies);
+            function updateNextStep() {
+                var fields = form.querySelectorAll('input[name="nextstep"]');
+                if (!fields.length) {
+                    return;
+                }
+                var next = computeNextStep();
+                Array.prototype.forEach.call(fields, function (field) {
+                    field.value = next || '';
+                });
+            }
+
+            function computeNextStep() {
+                var step = currentStep || stepOrder[0] || '';
+                if (!step) {
+                    return '';
+                }
+
+                var questions = stepQuestions[step] || [];
+                for (var i = 0; i < questions.length; i++) {
+                    var key = questions[i];
+                    var question = structure[key];
+                    if (!question) {
+                        continue;
+                    }
+                    var value = readAnswer(question);
+                    if (value === null || typeof value === 'undefined' || (Array.isArray(value) && !value.length)) {
+                        continue;
+                    }
+
+                    var manual = manualQuestionRouting(question, value);
+                    if (manual) {
+                        return manual;
+                    }
+
+                    var dependencyNext = dependencyRouting(question, value);
+                    if (dependencyNext) {
+                        return dependencyNext;
                     }
                 }
-            });
+
+                var manualStep = manualStepRouting(step);
+                if (manualStep) {
+                    return manualStep;
+                }
+
+                var index = stepOrder.indexOf(step);
+                if (index !== -1 && index + 1 < stepOrder.length) {
+                    return stepOrder[index + 1];
+                }
+
+                return finalStep;
+            }
+
+            function manualQuestionRouting(question, value) {
+                var name = question.name || question.key;
+                var handlers = {
+                    'age': function (val) {
+                        if (Array.isArray(val)) {
+                            val = val[0];
+                        }
+                        if (val === 'under18') {
+                            return 'under18';
+                        }
+                        if (val === '75over') {
+                            return '75over';
+                        }
+                        if (val === '18to74') {
+                            return '18to74';
+                        }
+                        return null;
+                    }
+                };
+
+                if (handlers[name]) {
+                    return handlers[name](value);
+                }
+
+                return null;
+            }
+
+            function manualStepRouting(step) {
+                return null;
+            }
+
+            function dependencyRouting(question, value) {
+                var key = question.key || question.name;
+                var questionDependencies = dependencies[key];
+                if (!questionDependencies) {
+                    return null;
+                }
+
+                var values = Array.isArray(value) ? value : [value];
+
+                for (var i = 0; i < questionDependencies.length; i++) {
+                    var dependency = questionDependencies[i];
+                    if (!dependency || !dependency.step) {
+                        continue;
+                    }
+                    var dependencyValues = dependency.values;
+                    if (typeof dependencyValues === 'undefined') {
+                        continue;
+                    }
+                    if (!Array.isArray(dependencyValues)) {
+                        dependencyValues = [dependencyValues];
+                    }
+
+                    for (var j = 0; j < values.length; j++) {
+                        if (dependencyValues.indexOf(values[j]) !== -1) {
+                            return dependency.step;
+                        }
+                    }
+                }
+
+                return null;
+            }
+
+            function readAnswer(question) {
+                var name = question.name || question.key;
+                if (!name) {
+                    return null;
+                }
+
+                var selector = '[name="' + cssEscape(name) + '"]';
+                if (question.type === 'checkbox') {
+                    var values = [];
+                    var nodes = form.querySelectorAll(selector);
+                    Array.prototype.forEach.call(nodes, function (node) {
+                        if (node.checked) {
+                            values.push(node.value);
+                        }
+                    });
+                    answerState[name] = values;
+                    return values;
+                }
+
+                if (question.type === 'radio') {
+                    var checked = form.querySelector(selector + ':checked');
+                    var radioValue = checked ? checked.value : null;
+                    answerState[name] = radioValue;
+                    return radioValue;
+                }
+
+                var input = form.querySelector(selector);
+                var inputValue = input ? input.value : null;
+                answerState[name] = inputValue;
+                return inputValue;
+            }
+
+            function setHiddenValue(questionKey, value) {
+                var field = document.getElementById(questionKey);
+                if (!field) {
+                    field = form.querySelector('[name="' + cssEscape(questionKey) + '"]');
+                }
+                if (!field) {
+                    field = form.querySelector('[name="' + cssEscape(questionKey) + '[]"]');
+                }
+                if (!field) {
+                    return;
+                }
+
+                if (field.type === 'checkbox') {
+                    var values = Array.isArray(value) ? value : [value];
+                    var nodes = form.querySelectorAll('[name="' + cssEscape(field.name) + '"]');
+                    Array.prototype.forEach.call(nodes, function (node) {
+                        node.checked = values.indexOf(node.value) !== -1;
+                    });
+                } else {
+                    field.value = value;
+                }
+
+                answerState[questionKey] = value;
+            }
+
+            function toggleActiveButtons(questionKey, value) {
+                if (!questionKey) {
+                    return;
+                }
+                var slug = slugify(questionKey);
+                var nodes = form.querySelectorAll('[data-question-option-key="' + slug + '"]');
+                if (!nodes.length) {
+                    return;
+                }
+
+                var values = Array.isArray(value) ? value.map(String) : [String(value)];
+                Array.prototype.forEach.call(nodes, function (node) {
+                    var parentButton = node.closest('button');
+                    if (!parentButton) {
+                        return;
+                    }
+                    var optionValue = node.getAttribute('data-question-option-value');
+                    if (optionValue && values.indexOf(optionValue) !== -1) {
+                        parentButton.classList.add('active');
+                    } else {
+                        parentButton.classList.remove('active');
+                    }
+                });
+            }
+
+            function readValueFromInput(input) {
+                if (input.type === 'checkbox') {
+                    var values = [];
+                    var nodes = form.querySelectorAll('[name="' + cssEscape(input.name) + '"]');
+                    Array.prototype.forEach.call(nodes, function (node) {
+                        if (node.checked) {
+                            values.push(node.value);
+                        }
+                    });
+                    return values;
+                }
+                if (input.type === 'radio') {
+                    return input.checked ? input.value : null;
+                }
+                return input.value;
+            }
         })();
     </script>
 </perch:form>

--- a/perch/templates/pages/client/reorder-questionnaire.php
+++ b/perch/templates/pages/client/reorder-questionnaire.php
@@ -141,7 +141,70 @@ if (is_array($reorder_structure) && PerchUtil::count($reorder_structure)) {
     if (is_array($reorder_dependencies) && PerchUtil::count($reorder_dependencies)) {
         PerchSystem::set_var('questionnaire_dependencies_json', PerchUtil::json_safe_encode($reorder_dependencies));
     }
+
+    $grouped_steps = [];
+    $step_sort_index = [];
+    foreach ($reorder_structure as $question) {
+        $step = isset($question['step']) && $question['step'] !== '' ? $question['step'] : $question['key'];
+        $question_sort = isset($question['sort']) ? (int)$question['sort'] : PHP_INT_MAX;
+
+        if (!isset($grouped_steps[$step])) {
+            $grouped_steps[$step] = [];
+            $step_sort_index[$step] = $question_sort;
+        } else {
+            if ($question_sort < $step_sort_index[$step]) {
+                $step_sort_index[$step] = $question_sort;
+            }
+        }
+
+        $grouped_steps[$step][] = $question['key'];
+    }
+
+    foreach ($grouped_steps as $step => &$keys) {
+        usort($keys, function ($a, $b) use ($reorder_structure) {
+            $definitionA = $reorder_structure[$a] ?? null;
+            $definitionB = $reorder_structure[$b] ?? null;
+
+            $sortA = is_array($definitionA) && isset($definitionA['sort']) ? (int)$definitionA['sort'] : PHP_INT_MAX;
+            $sortB = is_array($definitionB) && isset($definitionB['sort']) ? (int)$definitionB['sort'] : PHP_INT_MAX;
+
+            if ($sortA === $sortB) {
+                return strcmp((string)$a, (string)$b);
+            }
+
+            return $sortA <=> $sortB;
+        });
+    }
+    unset($keys);
+
+    if (PerchUtil::count($grouped_steps)) {
+        if (PerchUtil::count($step_sort_index)) {
+            asort($step_sort_index, SORT_NUMERIC);
+            $ordered_steps = [];
+            foreach (array_keys($step_sort_index) as $stepKey) {
+                $ordered_steps[$stepKey] = $grouped_steps[$stepKey];
+            }
+            $grouped_steps = $ordered_steps;
+        }
+
+        PerchSystem::set_var('questionnaire_steps_json', PerchUtil::json_safe_encode($grouped_steps));
+        reset($grouped_steps);
+        $first_step = key($grouped_steps);
+        if (!$first_step) {
+            $first_step = 'weight';
+        }
+        $current_step = $_GET['step'] ?? $first_step;
+        PerchSystem::set_var('questionnaire_default_step', $first_step);
+        PerchSystem::set_var('questionnaire_current_step', $current_step);
+    }
 }
+
+$reorder_answers = $_SESSION['questionnaire-reorder'] ?? [];
+if (PerchUtil::count($reorder_answers)) {
+    PerchSystem::set_var('questionnaire_answers_json', PerchUtil::json_safe_encode($reorder_answers));
+}
+
+PerchSystem::set_var('previousPage', '/client/re-order');
 
  perch_form('reorder-questionnaire.html');
 

--- a/perch/templates/pages/getStarted/review-questionnaire.php
+++ b/perch/templates/pages/getStarted/review-questionnaire.php
@@ -5,10 +5,25 @@ if (empty($_SESSION['questionnaire']) && isset($_COOKIE['questionnaire'])) {
 }
 
 $structure = perch_member_questionnaire_structure('first-order');
+if (is_array($structure) && PerchUtil::count($structure)) {
+    uasort($structure, function ($a, $b) {
+        $sortA = isset($a['sort']) ? (int)$a['sort'] : PHP_INT_MAX;
+        $sortB = isset($b['sort']) ? (int)$b['sort'] : PHP_INT_MAX;
+
+        if ($sortA === $sortB) {
+            $keyA = isset($a['key']) ? (string)$a['key'] : '';
+            $keyB = isset($b['key']) ? (string)$b['key'] : '';
+            return strcmp($keyA, $keyB);
+        }
+
+        return $sortA <=> $sortB;
+    });
+}
 $question_labels = [];
 $question_steps = [];
 $question_definitions = [];
 $alias_map = [];
+$canonical_answers = [];
 
 if (is_array($structure)) {
     foreach ($structure as $key => $question) {
@@ -30,17 +45,93 @@ if (is_array($structure)) {
     }
 }
 
+$answers = $_SESSION['questionnaire'] ?? [];
+if (is_array($answers)) {
+    foreach ($answers as $answerKey => $value) {
+        if (!array_key_exists($answerKey, $alias_map)) {
+            continue;
+        }
+
+        $canonicalKey = $alias_map[$answerKey];
+        $canonical_answers[$canonicalKey] = $value;
+    }
+}
+
 // Render a field with optional second value and unit
 function renderMeasurement($value, $unitKey, $secondKey, $questionnaire) {
-    $output = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
-    if (isset($questionnaire[$unitKey])) {
-        $unitParts = explode("-", $questionnaire[$unitKey]);
-        $output .= " " . htmlspecialchars($unitParts[0]);
-        if (isset($questionnaire[$secondKey])) {
-            $output .= " " . htmlspecialchars($questionnaire[$secondKey]) . " " . htmlspecialchars($unitParts[1]);
+    $primary = trim((string)$value);
+    $units = isset($questionnaire[$unitKey]) ? (string)$questionnaire[$unitKey] : '';
+    $secondary = isset($questionnaire[$secondKey]) ? trim((string)$questionnaire[$secondKey]) : '';
+
+    $unitParts = $units !== '' ? explode('-', $units) : [];
+    $primaryUnit = isset($unitParts[0]) ? trim((string)$unitParts[0]) : '';
+    $secondaryUnit = isset($unitParts[1]) ? trim((string)$unitParts[1]) : '';
+
+    $segments = [];
+
+    if ($primary !== '') {
+        $segments[] = $primary;
+        if ($primaryUnit !== '') {
+            $segments[] = $primaryUnit;
         }
     }
-    return $output;
+
+    if ($secondary !== '') {
+        $segments[] = $secondary;
+        if ($secondaryUnit !== '') {
+            $segments[] = $secondaryUnit;
+        }
+    }
+
+    return trim(implode(' ', array_filter($segments, function ($segment) {
+        return $segment !== '';
+    })));
+}
+
+function extractOptionDisplay($option, $fallback)
+{
+    if (is_array($option)) {
+        foreach (['label', 'title', 'text', 'value'] as $key) {
+            if (isset($option[$key]) && $option[$key] !== '') {
+                return $option[$key];
+            }
+        }
+
+        $scalars = array_filter($option, function ($item) {
+            return is_scalar($item) && $item !== '';
+        });
+
+        if (!empty($scalars)) {
+            return implode(' ', array_map('strval', $scalars));
+        }
+
+        return $fallback;
+    }
+
+    if ($option === '' || $option === null) {
+        return $fallback;
+    }
+
+    return $option;
+}
+
+function resolveOptionLabel($options, $value)
+{
+    if (!is_array($options) || empty($options)) {
+        return $value;
+    }
+
+    if (array_key_exists($value, $options)) {
+        return extractOptionDisplay($options[$value], $value);
+    }
+
+    foreach ($options as $option) {
+        if (is_array($option) && isset($option['value']) && (string)$option['value'] === (string)$value) {
+            return extractOptionDisplay($option, $value);
+        }
+    }
+
+    return $value;
 }
 
 // Page header
@@ -65,65 +156,74 @@ $_SESSION['questionnaire']["reviewed"] = "InProcess";
                 }
             }
 
-            foreach ($_SESSION['questionnaire'] as $key => $value) {
-                $canonicalKey = $alias_map[$key] ?? $key;
-                if (!isset($question_labels[$canonicalKey])) {
-                    continue;
-                }
+            if (is_array($structure) && PerchUtil::count($canonical_answers)) {
+                foreach ($structure as $canonicalKey => $definition) {
+                    if (!array_key_exists($canonicalKey, $question_labels)) {
+                        continue;
+                    }
 
-                $definition = $question_definitions[$canonicalKey] ?? [];
-                if (($definition['type'] ?? '') === 'hidden') {
-                    continue;
-                }
+                    if (($definition['type'] ?? '') === 'hidden') {
+                        continue;
+                    }
 
-                $changelink = "/get-started/questionnaire?step=" . ($question_steps[$canonicalKey] ?? $canonicalKey);
+                    if (!array_key_exists($canonicalKey, $canonical_answers)) {
+                        continue;
+                    }
+
+                    $value = $canonical_answers[$canonicalKey];
+                    $options = isset($definition['options']) && is_array($definition['options']) ? $definition['options'] : [];
+
+                    if (is_array($value)) {
+                        $labels = [];
+                        foreach ($value as $item) {
+                            $labels[] = resolveOptionLabel($options, $item);
+                        }
+                        $labels = array_filter($labels, function ($label) {
+                            return $label !== '' && $label !== null;
+                        });
+                        $rawDisplay = $labels ? implode(', ', array_map('strval', $labels)) : implode(', ', array_map('strval', $value));
+                    } else {
+                        $rawDisplay = resolveOptionLabel($options, $value);
+                        if ($rawDisplay === '' && $value !== null) {
+                            $rawDisplay = (string)$value;
+                        }
+                    }
+
+                    $measurementDisplay = '';
+                    if (!is_array($value)) {
+                        if ($canonicalKey === 'weight') {
+                            $measurementDisplay = renderMeasurement($value, 'weightunit', 'weight2', $_SESSION['questionnaire']);
+                        } elseif ($canonicalKey === 'weight-wegovy') {
+                            $measurementDisplay = renderMeasurement($value, 'unit-wegovy', 'weight2-wegovy', $_SESSION['questionnaire']);
+                        } elseif ($canonicalKey === 'height') {
+                            $measurementDisplay = renderMeasurement($value, 'heightunit', 'height2', $_SESSION['questionnaire']);
+                        }
+                    }
+
+                    $displayValue = $measurementDisplay !== '' ? $measurementDisplay : $rawDisplay;
+                    if ($displayValue === '') {
+                        $displayValue = is_array($value)
+                            ? implode(', ', array_map('strval', $value))
+                            : (string)$value;
+                    }
+
+                    $displayValue = trim((string)$displayValue);
+                    $changelink = "/get-started/questionnaire?step=" . ($question_steps[$canonicalKey] ?? $canonicalKey);
             ?>
             <div class="plan">
                 <div>
-                    <h5><?= htmlspecialchars($question_labels[$canonicalKey]) ?></h5>
-                    <p>
-                        <?php
-                        $displayValue = '';
-                        $options = isset($definition['options']) && is_array($definition['options']) ? $definition['options'] : [];
-
-                        if (is_array($value)) {
-                            if ($options) {
-                                $labels = [];
-                                foreach ($value as $item) {
-                                    $labels[] = $options[$item] ?? $item;
-                                }
-                                $displayValue = implode(', ', $labels);
-                            } else {
-                                $displayValue = implode(', ', $value);
-                            }
-                        } else {
-                            if ($options && isset($options[$value])) {
-                                $displayValue = $options[$value];
-                            } else {
-                                $displayValue = $value;
-                            }
-                        }
-
-                        if ($canonicalKey === "weight") {
-                            $displayValue = renderMeasurement($value, "weightunit", "weight2", $_SESSION['questionnaire']);
-                        } elseif ($canonicalKey === "weight-wegovy") {
-                            $displayValue = renderMeasurement($value, "unit-wegovy", "weight2-wegovy", $_SESSION['questionnaire']);
-                        } elseif ($canonicalKey === "height") {
-                            $displayValue = renderMeasurement($value, "heightunit", "height2", $_SESSION['questionnaire']);
-                        }
-
-                        echo htmlspecialchars($displayValue, ENT_QUOTES, 'UTF-8');
-                        ?>
-                    </p>
+                    <h5><?= htmlspecialchars($question_labels[$canonicalKey], ENT_QUOTES, 'UTF-8') ?></h5>
+                    <p><?= htmlspecialchars($displayValue, ENT_QUOTES, 'UTF-8') ?></p>
                 </div>
                 <div class="price-section">
                     <button style="background-color: #00ccbd;text-transform: uppercase;" class="badge text-dark loss">
-                        <a style="text-decoration: none; color:black;" href="<?= $changelink ?>">Review Answer</a>
+                        <a style="text-decoration: none; color:black;" href="<?= htmlspecialchars($changelink, ENT_QUOTES, 'UTF-8') ?>">Review Answer</a>
                     </button>
                 </div>
             </div>
             <?php
                 }
+            }
             ?>
         </div>
 


### PR DESCRIPTION
## Summary
- map stored questionnaire answers to canonical keys derived from the database structure so the review screen follows the same ordering and skips hidden questions
- add helpers to normalise option labels and measurement outputs, ensuring review values reuse the labels and units defined in the questionnaire data
- escape the review answer link target for safety
- surface admin sort metadata for questionnaire questions and ensure both the form navigation and review views honour that order

## Testing
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
- php -l perch/templates/pages/getStarted/questionnaire.php
- php -l perch/templates/pages/client/reorder-questionnaire.php
- php -l perch/templates/pages/getStarted/review-questionnaire.php

------
https://chatgpt.com/codex/tasks/task_b_68cd66617d408324a31c10433af25550