### PR TITLE
Use questionnaire dependencies for age-based routing

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
@@ -109,7 +109,15 @@ class PerchMembers_Questionnaires extends PerchAPI_Factory
                 $update['stepSlug'] = $definition['step'];
             }
 
-            if ((empty($row['dependencies'])) && isset($definition['dependencies'])) {
+            $dependencies_empty = empty($row['dependencies']);
+            if (!$dependencies_empty) {
+                $decoded_dependencies = PerchUtil::json_safe_decode($row['dependencies'], true);
+                if (is_array($decoded_dependencies) && !PerchUtil::count($decoded_dependencies)) {
+                    $dependencies_empty = true;
+                }
+            }
+
+            if ($dependencies_empty && isset($definition['dependencies'])) {
                 $encoded = PerchUtil::json_safe_encode($definition['dependencies']);
                 if ($encoded !== false) {
                     $update['dependencies'] = $encoded;

--- a/perch/addons/apps/perch_members/questionnaire_default_questions.php
+++ b/perch/addons/apps/perch_members/questionnaire_default_questions.php
@@ -128,6 +128,20 @@ return [
                 '75over' => '75 or over',
             ],
             'step' => 'howold',
+            'dependencies' => [
+                [
+                    'values' => ['under18'],
+                    'step'   => 'under18',
+                ],
+                [
+                    'values' => ['75over'],
+                    'step'   => '75over',
+                ],
+                [
+                    'values' => ['18to74'],
+                    'step'   => '18to74',
+                ],
+            ],
         ],
         'ethnicity' => [
             'label' => 'Which ethnicity are you?',

--- a/perch/templates/forms/questionnaire.html
+++ b/perch/templates/forms/questionnaire.html
@@ -1809,20 +1809,10 @@
                         continue;
                     }
 
-                    var manual = manualQuestionRouting(question, value);
-                    if (manual) {
-                        return manual;
-                    }
-
                     var dependencyNext = dependencyRouting(question, value);
                     if (dependencyNext) {
                         return dependencyNext;
                     }
-                }
-
-                var manualStep = manualStepRouting(step);
-                if (manualStep) {
-                    return manualStep;
                 }
 
                 var index = stepOrder.indexOf(step);
@@ -1831,37 +1821,6 @@
                 }
 
                 return finalStep;
-            }
-
-            function manualQuestionRouting(question, value) {
-                var name = question.name || question.key;
-                var handlers = {
-                    'age': function (val) {
-                        if (Array.isArray(val)) {
-                            val = val[0];
-                        }
-                        if (val === 'under18') {
-                            return 'under18';
-                        }
-                        if (val === '75over') {
-                            return '75over';
-                        }
-                        if (val === '18to74') {
-                            return '18to74';
-                        }
-                        return null;
-                    }
-                };
-
-                if (handlers[name]) {
-                    return handlers[name](value);
-                }
-
-                return null;
-            }
-
-            function manualStepRouting(step) {
-                return null;
             }
 
             function dependencyRouting(question, value) {

--- a/perch/templates/forms/reorder-questionnaire.html
+++ b/perch/templates/forms/reorder-questionnaire.html
@@ -642,20 +642,10 @@
                         continue;
                     }
 
-                    var manual = manualQuestionRouting(question, value);
-                    if (manual) {
-                        return manual;
-                    }
-
                     var dependencyNext = dependencyRouting(question, value);
                     if (dependencyNext) {
                         return dependencyNext;
                     }
-                }
-
-                var manualStep = manualStepRouting(step);
-                if (manualStep) {
-                    return manualStep;
                 }
 
                 var index = stepOrder.indexOf(step);
@@ -664,37 +654,6 @@
                 }
 
                 return finalStep;
-            }
-
-            function manualQuestionRouting(question, value) {
-                var name = question.name || question.key;
-                var handlers = {
-                    'age': function (val) {
-                        if (Array.isArray(val)) {
-                            val = val[0];
-                        }
-                        if (val === 'under18') {
-                            return 'under18';
-                        }
-                        if (val === '75over') {
-                            return '75over';
-                        }
-                        if (val === '18to74') {
-                            return '18to74';
-                        }
-                        return null;
-                    }
-                };
-
-                if (handlers[name]) {
-                    return handlers[name](value);
-                }
-
-                return null;
-            }
-
-            function manualStepRouting(step) {
-                return null;
             }
 
             function dependencyRouting(question, value) {


### PR DESCRIPTION
## Summary
- add dependency metadata for the age question so routing comes from the questionnaire table
- allow questionnaire metadata backfill to refresh empty dependency arrays
- drop hard-coded age routing logic in the first-order and reorder questionnaire templates to rely on DB-provided dependencies

## Testing
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
- php -l perch/addons/apps/perch_members/questionnaire_default_questions.php

------
https://chatgpt.com/codex/tasks/task_b_68cd85c697288324bcbc0052afda2a12