### PR TITLE
Enable admin editing of questionnaire metadata

### DIFF
--- a/perch/addons/apps/perch_members/modes/questions.edit.post.php
+++ b/perch/addons/apps/perch_members/modes/questions.edit.post.php
@@ -16,6 +16,12 @@
 
         echo $Form->text_field('label', 'Label', isset($details['label'])?$details['label']:false);
 
+        echo $Form->hint($Lang->get('Leave blank to reuse the question key as the form field name.'));
+        echo $Form->text_field('fieldName', 'Form field name', isset($details['fieldName'])?$details['fieldName']:false);
+
+        echo $Form->hint($Lang->get('Defines the questionnaire step slug. Leave blank to reuse the question key.'));
+        echo $Form->text_field('stepSlug', 'Step slug', isset($details['stepSlug'])?$details['stepSlug']:false);
+
         echo $Form->select_field('type', 'Field type', [
             ['value'=>'text','label'=>'Text'],
             ['value'=>'textarea','label'=>'Textarea'],
@@ -26,6 +32,9 @@
         ], isset($details['type'])?$details['type']:'text');
 
         echo $Form->textarea_field('options', 'Options (value:label per line)', isset($details['options'])?$details['options']:'');
+
+        echo $Form->hint($Lang->get('Provide dependency rules as JSON. Each rule should include "values" and optionally "question" and "step" keys. Leave blank if not required.'));
+        echo $Form->textarea_field('dependencies', 'Dependencies (JSON)', isset($details['dependencies'])?$details['dependencies']:'', 'input-simple code');
 
         echo $Form->hint($Lang->get('Use numbers to control the question order shown to clients. Lower numbers display first; leave blank to add to the end.'));
         echo $Form->text_field('sort', 'Display order', isset($details['sort'])?$details['sort']:'');

--- a/perch/addons/apps/perch_members/modes/questions.edit.pre.php
+++ b/perch/addons/apps/perch_members/modes/questions.edit.pre.php
@@ -14,6 +14,12 @@
                 $details['options'] = implode("\n", $lines);
             }
         }
+        if (isset($details['dependencies']) && $details['dependencies'] !== '') {
+            $deps = PerchUtil::json_safe_decode($details['dependencies'], true);
+            if (is_array($deps)) {
+                $details['dependencies'] = PerchUtil::json_safe_encode($deps, true);
+            }
+        }
         $heading1 = $Lang->get('Editing question');
     } else {
         $Question = false;
@@ -26,12 +32,15 @@
     $Form->require_field('questionKey', 'Required');
 
     if ($Form->submitted()) {
-        $postvars = ['questionnaireType','questionKey','label','type','options','sort'];
+        $postvars = ['questionnaireType','questionKey','label','type','options','fieldName','stepSlug','dependencies','sort'];
         $data = $Form->receive($postvars);
+
+        $options_input = isset($data['options']) ? trim($data['options']) : '';
         if (isset($data['options'])) {
-            $opts = preg_split('/\r\n|\r|\n/', trim($data['options']));
+            $opts = preg_split('/\r\n|\r|\n/', $options_input);
             $json = [];
             foreach($opts as $line) {
+                $line = trim($line);
                 if ($line==='') continue;
                 $parts = explode(':', $line, 2);
                 if (count($parts)==2) {
@@ -40,7 +49,39 @@
                     $json[$line] = $line;
                 }
             }
-            $data['options'] = json_encode($json);
+            $data['options'] = PerchUtil::json_safe_encode($json);
+        }
+
+        $dependencies_input = isset($data['dependencies']) ? trim($data['dependencies']) : '';
+        $dependencies_valid = true;
+        if ($dependencies_input === '') {
+            $data['dependencies'] = null;
+        } else {
+            $decoded_dependencies = PerchUtil::json_safe_decode($dependencies_input, true);
+            if (!is_array($decoded_dependencies)) {
+                $dependencies_valid = false;
+                $Form->error = true;
+                $Form->messages['dependencies'] = $Lang->get('Dependencies must be valid JSON.');
+                $message = $HTML->failure_message($Lang->get('Dependencies must be valid JSON.'));
+            } else {
+                $encoded = PerchUtil::json_safe_encode($decoded_dependencies);
+                if ($encoded === false) {
+                    $dependencies_valid = false;
+                    $Form->error = true;
+                    $Form->messages['dependencies'] = $Lang->get('Dependencies must be valid JSON.');
+                    $message = $HTML->failure_message($Lang->get('Dependencies must be valid JSON.'));
+                } else {
+                    $data['dependencies'] = $encoded;
+                }
+            }
+        }
+
+        if (isset($data['fieldName']) && $data['fieldName'] === '') {
+            $data['fieldName'] = null;
+        }
+
+        if (isset($data['stepSlug']) && $data['stepSlug'] === '') {
+            $data['stepSlug'] = null;
         }
 
         if (!isset($data['sort']) || !is_numeric($data['sort'])) {
@@ -52,20 +93,32 @@
             }
         }
 
-        if ($Question) {
-            $Question->update($data);
-        } else {
-            $Question = $Questions->create($data);
-        }
-        $message = $HTML->success_message('Question has been successfully saved. Return to %squestion listing%s', '<a href="'.$API->app_path().'/questionnaire_questions/">', '</a>');
-        $details = $Question->to_array();
-        if (isset($details['options'])) {
-            $opts = PerchUtil::json_safe_decode($details['options'], true);
-            if (is_array($opts)) {
-                $lines = [];
-                foreach($opts as $k=>$v) $lines[] = $k.':'.$v;
-                $details['options'] = implode("\n", $lines);
+        if ($dependencies_valid) {
+            if ($Question) {
+                $Question->update($data);
+            } else {
+                $Question = $Questions->create($data);
             }
+            $message = $HTML->success_message('Question has been successfully saved. Return to %squestion listing%s', '<a href="'.$API->app_path().'/questionnaire_questions/">', '</a>');
+            $details = $Question->to_array();
+            if (isset($details['options'])) {
+                $opts = PerchUtil::json_safe_decode($details['options'], true);
+                if (is_array($opts)) {
+                    $lines = [];
+                    foreach($opts as $k=>$v) $lines[] = $k.':'.$v;
+                    $details['options'] = implode("\n", $lines);
+                }
+            }
+            if (isset($details['dependencies']) && $details['dependencies'] !== '') {
+                $deps = PerchUtil::json_safe_decode($details['dependencies'], true);
+                if (is_array($deps)) {
+                    $details['dependencies'] = PerchUtil::json_safe_encode($deps, true);
+                }
+            }
+        } else {
+            $details = array_merge($details, $data);
+            $details['options'] = $options_input;
+            $details['dependencies'] = $dependencies_input;
         }
     }
 ?>

--- a/perch/addons/apps/perch_members/modes/questions.list.post.php
+++ b/perch/addons/apps/perch_members/modes/questions.list.post.php
@@ -38,6 +38,54 @@
         ]);
 
     $Listing->add_col([
+            'title' => $Lang->get('Field name'),
+            'value' => function ($Question, $HTML, $Lang) {
+                $field = $Question->fieldName();
+                if ($field === null || $field === '') {
+                    $field = $Question->questionKey();
+                }
+
+                return $HTML->encode($field);
+            },
+            'sort'  => 'fieldName',
+        ]);
+
+    $Listing->add_col([
+            'title' => $Lang->get('Step'),
+            'value' => function ($Question, $HTML, $Lang) {
+                $step = $Question->stepSlug();
+                if ($step === null || $step === '') {
+                    return $HTML->encode('—');
+                }
+
+                return $HTML->encode($step);
+            },
+            'sort'  => 'stepSlug',
+        ]);
+
+    $Listing->add_col([
+            'title' => $Lang->get('Dependencies'),
+            'value' => function ($Question, $HTML, $Lang) {
+                $raw = $Question->dependencies();
+                if (!$raw) {
+                    return $HTML->encode('—');
+                }
+
+                $decoded = PerchUtil::json_safe_decode($raw, true);
+                if (!is_array($decoded)) {
+                    return $HTML->encode('—');
+                }
+
+                $count = PerchUtil::count($decoded);
+                if ($count === false || $count === 0) {
+                    return $HTML->encode('—');
+                }
+
+                return $HTML->encode((string)$count);
+            },
+        ]);
+
+    $Listing->add_col([
             'title' => $Lang->get('Answers'),
             'value' => function ($Question, $HTML, $Lang) {
                 $summary = $Question->option_summary();


### PR DESCRIPTION
## Summary
- expose questionnaire field name, step slug, and dependency settings in the admin question editor with JSON validation
- pretty-print stored dependency data when editing existing questions and reuse entered values when validation fails
- show the configured field name, step, and dependency count in the question listing for better visibility

## Testing
- php -l perch/addons/apps/perch_members/modes/questions.edit.pre.php
- php -l perch/addons/apps/perch_members/modes/questions.edit.post.php
- php -l perch/addons/apps/perch_members/modes/questions.list.post.php

------
https://chatgpt.com/codex/tasks/task_b_68ce5a3d52bc8324bbf273e1a2537311