### PR TITLE
Visualize questionnaire flows in admin

### DIFF
--- a/perch/addons/apps/perch_members/assets/css/questionnaire-flowchart.css
+++ b/perch/addons/apps/perch_members/assets/css/questionnaire-flowchart.css
@@ -1,0 +1,261 @@
+.questionnaire-flowchart {
+    position: relative;
+    margin-top: 1.5rem;
+}
+
+.flowchart-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 1rem 0 0.75rem;
+}
+
+.flowchart-toolbar__tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.flowchart-toolbar__tab {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid #ccd5ff;
+    background: #f3f5ff;
+    color: #1f2937;
+    font-size: 0.85rem;
+    text-decoration: none;
+    transition: all 0.2s ease;
+}
+
+.flowchart-toolbar__tab:hover {
+    background: #e4e9ff;
+    border-color: #a9b8ff;
+}
+
+.flowchart-toolbar__tab.is-active {
+    background: #3657ff;
+    border-color: #3657ff;
+    color: #ffffff;
+}
+
+.flowchart-toolbar__hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #4b5563;
+}
+
+.flowchart-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    margin-bottom: 0.75rem;
+    font-size: 0.82rem;
+    color: #475569;
+}
+
+.flowchart-legend__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.flowchart-legend__swatch {
+    width: 16px;
+    height: 10px;
+    background: linear-gradient(90deg, rgba(91,124,250,0.15), rgba(91,124,250,0.65));
+    border-radius: 6px;
+    border: 1px solid rgba(91,124,250,0.4);
+}
+
+.flowchart-legend__note {
+    opacity: 0.85;
+}
+
+.flowchart-canvas {
+    display: none;
+    position: relative;
+    background: #ffffff;
+    border: 1px solid #d8deeb;
+    border-radius: 8px;
+    padding: 1.5rem;
+    min-height: 340px;
+    overflow: auto;
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,0.8);
+}
+
+.flowchart-canvas.is-active {
+    display: block;
+}
+
+.flowchart-grid {
+    display: flex;
+    align-items: flex-start;
+    gap: 1.5rem;
+    min-width: 100%;
+}
+
+.flowchart-step {
+    flex: 0 0 260px;
+    min-width: 240px;
+    background: #f4f7ff;
+    border: 1px solid #c7d4fb;
+    border-radius: 8px;
+    padding: 1rem;
+    box-shadow: 0 4px 12px rgba(15,23,42,0.04);
+}
+
+.flowchart-step__header {
+    border-bottom: 1px solid #bcc8f2;
+    padding-bottom: 0.45rem;
+    margin-bottom: 0.75rem;
+}
+
+.flowchart-step__title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #253053;
+}
+
+.flowchart-step__questions {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.flowchart-node {
+    background: #ffffff;
+    border: 1px solid #c6d1f0;
+    border-radius: 8px;
+    padding: 0.85rem;
+    box-shadow: 0 2px 6px rgba(30,64,175,0.08);
+    transition: box-shadow 0.2s ease, border-color 0.2s ease;
+    position: relative;
+}
+
+.flowchart-node[data-edit-url] {
+    cursor: pointer;
+}
+
+.flowchart-node:hover {
+    border-color: #7c91ff;
+    box-shadow: 0 6px 20px rgba(30,64,175,0.12);
+}
+
+.flowchart-node__header {
+    margin-bottom: 0.5rem;
+}
+
+.flowchart-node__title {
+    margin: 0;
+    font-size: 0.95rem;
+    color: #1f2937;
+}
+
+.flowchart-node__meta dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.35rem 0.75rem;
+    font-size: 0.78rem;
+    color: #374151;
+}
+
+.flowchart-node__meta dt {
+    font-weight: 600;
+    color: #475569;
+}
+
+.flowchart-node__meta dd {
+    margin: 0;
+    color: #0f172a;
+    word-break: break-word;
+}
+
+.flowchart-node__options,
+.flowchart-node__dependencies {
+    margin-top: 0.7rem;
+    font-size: 0.78rem;
+    color: #1f2937;
+}
+
+.flowchart-node__options ul,
+.flowchart-node__dependencies ul {
+    margin: 0.4rem 0 0;
+    padding-left: 1.1rem;
+}
+
+.flowchart-node__options li,
+.flowchart-node__dependencies li {
+    margin-bottom: 0.3rem;
+    line-height: 1.35;
+}
+
+.flowchart-node__option-value {
+    color: #64748b;
+    font-size: 0.75rem;
+}
+
+.flowchart-node__option-more {
+    color: #64748b;
+    font-style: italic;
+}
+
+.flowchart-node__footer {
+    margin-top: 0.75rem;
+    text-align: right;
+}
+
+.flowchart-node__edit {
+    font-size: 0.78rem;
+    color: #2563eb;
+    text-decoration: none;
+}
+
+.flowchart-node__edit:hover,
+.flowchart-node__edit:focus {
+    text-decoration: underline;
+}
+
+.flowchart-connections {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
+
+.flowchart-connection {
+    stroke: #5b7cfa;
+    stroke-width: 2;
+    fill: none;
+    opacity: 0.75;
+}
+
+.flowchart-connection__label {
+    fill: #1f2937;
+    font-size: 0.72rem;
+    text-anchor: middle;
+    dominant-baseline: middle;
+    paint-order: stroke;
+    stroke: #ffffff;
+    stroke-width: 3px;
+}
+
+.flowchart-empty {
+    padding: 1rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+}
+
+@media (max-width: 960px) {
+    .flowchart-grid {
+        flex-direction: column;
+    }
+
+    .flowchart-step {
+        width: 100%;
+    }
+}

--- a/perch/addons/apps/perch_members/assets/js/questionnaire-flowchart.js
+++ b/perch/addons/apps/perch_members/assets/js/questionnaire-flowchart.js
@@ -1,0 +1,269 @@
+(function () {
+    var SVG_NS = 'http://www.w3.org/2000/svg';
+
+    function parseJSONScript(el) {
+        if (!el) return null;
+        try {
+            return JSON.parse(el.textContent || el.innerText || '{}');
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function ensureArrowMarker(svg) {
+        var existing = svg.querySelector('#flowchart-arrow');
+        if (existing) {
+            return 'flowchart-arrow';
+        }
+
+        var defs = document.createElementNS(SVG_NS, 'defs');
+        var marker = document.createElementNS(SVG_NS, 'marker');
+        marker.setAttribute('id', 'flowchart-arrow');
+        marker.setAttribute('viewBox', '0 0 10 10');
+        marker.setAttribute('refX', '9');
+        marker.setAttribute('refY', '5');
+        marker.setAttribute('markerWidth', '6');
+        marker.setAttribute('markerHeight', '6');
+        marker.setAttribute('orient', 'auto');
+
+        var path = document.createElementNS(SVG_NS, 'path');
+        path.setAttribute('d', 'M 0 0 L 10 5 L 0 10 z');
+        path.setAttribute('fill', '#5b7cfa');
+        path.setAttribute('opacity', '0.75');
+
+        marker.appendChild(path);
+        defs.appendChild(marker);
+        svg.appendChild(defs);
+
+        return 'flowchart-arrow';
+    }
+
+    function truncateLabel(label) {
+        if (!label) return '';
+        if (label.length <= 40) return label;
+        return label.slice(0, 37) + '\u2026';
+    }
+
+    function drawPath(svg, container, fromEl, toEl, label) {
+        if (!fromEl || !toEl) return;
+
+        var containerRect = container.getBoundingClientRect();
+        var fromRect = fromEl.getBoundingClientRect();
+        var toRect = toEl.getBoundingClientRect();
+
+        var scrollLeft = container.scrollLeft || 0;
+        var scrollTop = container.scrollTop || 0;
+
+        var startX = fromRect.left + fromRect.width / 2 - containerRect.left + scrollLeft;
+        var startY = fromRect.bottom - containerRect.top + scrollTop;
+        var endX = toRect.left + toRect.width / 2 - containerRect.left + scrollLeft;
+        var endY = toRect.top - containerRect.top + scrollTop;
+
+        if (startX === endX && startY === endY) {
+            return;
+        }
+
+        var controlX = (startX + endX) / 2;
+
+        var path = document.createElementNS(SVG_NS, 'path');
+        path.setAttribute('d', 'M ' + startX + ' ' + startY + ' C ' + controlX + ' ' + startY + ' ' + controlX + ' ' + endY + ' ' + endX + ' ' + endY);
+        path.setAttribute('class', 'flowchart-connection');
+        path.setAttribute('marker-end', 'url(#' + ensureArrowMarker(svg) + ')');
+        svg.appendChild(path);
+
+        if (label) {
+            var text = document.createElementNS(SVG_NS, 'text');
+            text.textContent = truncateLabel(label);
+            text.setAttribute('x', controlX);
+            text.setAttribute('y', (startY + endY) / 2);
+            text.setAttribute('class', 'flowchart-connection__label');
+            svg.appendChild(text);
+        }
+    }
+
+    function drawConnections(canvas) {
+        var svg = canvas.querySelector('.flowchart-connections');
+        if (!svg) return;
+
+        while (svg.firstChild) {
+            svg.removeChild(svg.firstChild);
+        }
+
+        var data = parseJSONScript(canvas.querySelector('.js-flowchart-data'));
+        if (!data || !data.questions) return;
+
+        var width = canvas.scrollWidth || canvas.clientWidth;
+        var height = canvas.scrollHeight || canvas.clientHeight;
+        svg.setAttribute('width', width);
+        svg.setAttribute('height', height);
+        svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+
+        var nodes = {};
+        var nodeEls = canvas.querySelectorAll('[data-question-key]');
+        Array.prototype.forEach.call(nodeEls, function (el) {
+            var key = el.getAttribute('data-question-key');
+            if (key) {
+                nodes[key] = el;
+            }
+        });
+
+        var steps = {};
+        var stepEls = canvas.querySelectorAll('[data-step-slug]');
+        Array.prototype.forEach.call(stepEls, function (el) {
+            var slug = el.getAttribute('data-step-slug');
+            if (slug) {
+                steps[slug] = el;
+            }
+        });
+
+        Object.keys(data.questions).forEach(function (key) {
+            var question = data.questions[key];
+            if (!question || !question.dependencies) return;
+            var fromEl = nodes[key];
+            if (!fromEl) return;
+
+            question.dependencies.forEach(function (dependency) {
+                if (!dependency) return;
+                var target = null;
+                if (dependency.question && nodes[dependency.question]) {
+                    target = nodes[dependency.question];
+                } else if (dependency.step && steps[dependency.step]) {
+                    target = steps[dependency.step];
+                }
+
+                if (!target || target === fromEl) {
+                    return;
+                }
+
+                var valuesLabel = Array.isArray(dependency.values) ? dependency.values.join(', ') : '';
+                drawPath(svg, canvas, fromEl, target, valuesLabel);
+            });
+        });
+    }
+
+    function setupNodeInteractions(container) {
+        var cards = container.querySelectorAll('.flowchart-node[data-edit-url]');
+        Array.prototype.forEach.call(cards, function (card) {
+            if (!card.hasAttribute('tabindex')) {
+                card.setAttribute('tabindex', '0');
+            }
+            if (!card.hasAttribute('role')) {
+                card.setAttribute('role', 'link');
+            }
+
+            card.addEventListener('click', function (event) {
+                if (event.defaultPrevented) return;
+                if (event.target && event.target.closest('a')) {
+                    return;
+                }
+                var url = card.getAttribute('data-edit-url');
+                if (url) {
+                    window.location.href = url;
+                }
+            });
+
+            card.addEventListener('keydown', function (event) {
+                if (event.target && event.target.closest('a')) {
+                    return;
+                }
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    var url = card.getAttribute('data-edit-url');
+                    if (url) {
+                        window.location.href = url;
+                    }
+                }
+            });
+        });
+    }
+
+    function initFlowchart(container) {
+        var canvases = container.querySelectorAll('[data-flowchart-canvas]');
+        if (!canvases.length) return;
+
+        var toggles = [];
+        if (container.parentNode) {
+            toggles = container.parentNode.querySelectorAll('[data-flowchart-tab]');
+        } else {
+            toggles = document.querySelectorAll('[data-flowchart-tab]');
+        }
+        var activeType = container.getAttribute('data-active-type');
+        if (!activeType && canvases[0]) {
+            activeType = canvases[0].getAttribute('data-flowchart-canvas');
+            container.setAttribute('data-active-type', activeType);
+        }
+
+        function updateActive(type) {
+            var found = false;
+            Array.prototype.forEach.call(canvases, function (canvas) {
+                var matches = canvas.getAttribute('data-flowchart-canvas') === type;
+                canvas.classList.toggle('is-active', matches);
+                if (matches) {
+                    found = true;
+                }
+            });
+            if (!found && canvases[0]) {
+                canvases[0].classList.add('is-active');
+                type = canvases[0].getAttribute('data-flowchart-canvas');
+            }
+            container.setAttribute('data-active-type', type);
+            Array.prototype.forEach.call(toggles, function (toggle) {
+                if (toggle.getAttribute('data-flowchart-tab')) {
+                    toggle.classList.toggle('is-active', toggle.getAttribute('data-flowchart-tab') === type);
+                }
+            });
+            requestAnimationFrame(renderConnections);
+        }
+
+        function renderConnections() {
+            Array.prototype.forEach.call(canvases, function (canvas) {
+                if (canvas.classList.contains('is-active')) {
+                    drawConnections(canvas);
+                }
+            });
+        }
+
+        Array.prototype.forEach.call(canvases, function (canvas) {
+            canvas.addEventListener('scroll', function () {
+                if (canvas.classList.contains('is-active')) {
+                    requestAnimationFrame(function () {
+                        drawConnections(canvas);
+                    });
+                }
+            });
+        });
+
+        Array.prototype.forEach.call(toggles, function (toggle) {
+            toggle.addEventListener('click', function (event) {
+                var targetType = toggle.getAttribute('data-flowchart-tab');
+                if (!targetType) return;
+                event.preventDefault();
+                updateActive(targetType);
+                var href = toggle.getAttribute('href');
+                if (href && window.history && typeof window.history.replaceState === 'function') {
+                    if (href.charAt(0) === '?') {
+                        var base = window.location.href.split('?')[0];
+                        window.history.replaceState({}, document.title, base + href);
+                    } else {
+                        window.history.replaceState({}, document.title, href);
+                    }
+                }
+            });
+        });
+
+        window.addEventListener('resize', function () {
+            requestAnimationFrame(renderConnections);
+        });
+
+        updateActive(activeType);
+        setupNodeInteractions(container);
+        renderConnections();
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var containers = document.querySelectorAll('[data-flowchart]');
+        Array.prototype.forEach.call(containers, function (container) {
+            initFlowchart(container);
+        });
+    });
+})();

--- a/perch/addons/apps/perch_members/modes/_subnav.php
+++ b/perch/addons/apps/perch_members/modes/_subnav.php
@@ -24,5 +24,6 @@
                 ['page'=>[
                                         'perch_members/questionnaire_questions',
                                         'perch_members/questionnaire_questions/edit',
+                                        'perch_members/questionnaire_questions/flowchart',
                         ], 'label'=>'Questionnaires',  'priv'=>'perch_members.questionnaires.manage'],
         ], $CurrentUser);

--- a/perch/addons/apps/perch_members/modes/questions.edit.post.php
+++ b/perch/addons/apps/perch_members/modes/questions.edit.post.php
@@ -16,6 +16,12 @@
 
         echo $Form->text_field('label', 'Label', isset($details['label'])?$details['label']:false);
 
+        echo $Form->hint($Lang->get('Leave blank to reuse the question key as the form field name.'));
+        echo $Form->text_field('fieldName', 'Form field name', isset($details['fieldName'])?$details['fieldName']:false);
+
+        echo $Form->hint($Lang->get('Defines the questionnaire step slug. Leave blank to reuse the question key.'));
+        echo $Form->text_field('stepSlug', 'Step slug', isset($details['stepSlug'])?$details['stepSlug']:false);
+
         echo $Form->select_field('type', 'Field type', [
             ['value'=>'text','label'=>'Text'],
             ['value'=>'textarea','label'=>'Textarea'],
@@ -26,6 +32,9 @@
         ], isset($details['type'])?$details['type']:'text');
 
         echo $Form->textarea_field('options', 'Options (value:label per line)', isset($details['options'])?$details['options']:'');
+
+        echo $Form->hint($Lang->get('Provide dependency rules as JSON. Each rule should include "values" and optionally "question" and "step" keys. Leave blank if not required.'));
+        echo $Form->textarea_field('dependencies', 'Dependencies (JSON)', isset($details['dependencies'])?$details['dependencies']:'', 'input-simple code');
 
         echo $Form->hint($Lang->get('Use numbers to control the question order shown to clients. Lower numbers display first; leave blank to add to the end.'));
         echo $Form->text_field('sort', 'Display order', isset($details['sort'])?$details['sort']:'');

--- a/perch/addons/apps/perch_members/modes/questions.edit.pre.php
+++ b/perch/addons/apps/perch_members/modes/questions.edit.pre.php
@@ -14,6 +14,12 @@
                 $details['options'] = implode("\n", $lines);
             }
         }
+        if (isset($details['dependencies']) && $details['dependencies'] !== '') {
+            $deps = PerchUtil::json_safe_decode($details['dependencies'], true);
+            if (is_array($deps)) {
+                $details['dependencies'] = PerchUtil::json_safe_encode($deps, true);
+            }
+        }
         $heading1 = $Lang->get('Editing question');
     } else {
         $Question = false;
@@ -26,12 +32,15 @@
     $Form->require_field('questionKey', 'Required');
 
     if ($Form->submitted()) {
-        $postvars = ['questionnaireType','questionKey','label','type','options','sort'];
+        $postvars = ['questionnaireType','questionKey','label','type','options','fieldName','stepSlug','dependencies','sort'];
         $data = $Form->receive($postvars);
+
+        $options_input = isset($data['options']) ? trim($data['options']) : '';
         if (isset($data['options'])) {
-            $opts = preg_split('/\r\n|\r|\n/', trim($data['options']));
+            $opts = preg_split('/\r\n|\r|\n/', $options_input);
             $json = [];
             foreach($opts as $line) {
+                $line = trim($line);
                 if ($line==='') continue;
                 $parts = explode(':', $line, 2);
                 if (count($parts)==2) {
@@ -40,7 +49,39 @@
                     $json[$line] = $line;
                 }
             }
-            $data['options'] = json_encode($json);
+            $data['options'] = PerchUtil::json_safe_encode($json);
+        }
+
+        $dependencies_input = isset($data['dependencies']) ? trim($data['dependencies']) : '';
+        $dependencies_valid = true;
+        if ($dependencies_input === '') {
+            $data['dependencies'] = null;
+        } else {
+            $decoded_dependencies = PerchUtil::json_safe_decode($dependencies_input, true);
+            if (!is_array($decoded_dependencies)) {
+                $dependencies_valid = false;
+                $Form->error = true;
+                $Form->messages['dependencies'] = $Lang->get('Dependencies must be valid JSON.');
+                $message = $HTML->failure_message($Lang->get('Dependencies must be valid JSON.'));
+            } else {
+                $encoded = PerchUtil::json_safe_encode($decoded_dependencies);
+                if ($encoded === false) {
+                    $dependencies_valid = false;
+                    $Form->error = true;
+                    $Form->messages['dependencies'] = $Lang->get('Dependencies must be valid JSON.');
+                    $message = $HTML->failure_message($Lang->get('Dependencies must be valid JSON.'));
+                } else {
+                    $data['dependencies'] = $encoded;
+                }
+            }
+        }
+
+        if (isset($data['fieldName']) && $data['fieldName'] === '') {
+            $data['fieldName'] = null;
+        }
+
+        if (isset($data['stepSlug']) && $data['stepSlug'] === '') {
+            $data['stepSlug'] = null;
         }
 
         if (!isset($data['sort']) || !is_numeric($data['sort'])) {
@@ -52,20 +93,32 @@
             }
         }
 
-        if ($Question) {
-            $Question->update($data);
-        } else {
-            $Question = $Questions->create($data);
-        }
-        $message = $HTML->success_message('Question has been successfully saved. Return to %squestion listing%s', '<a href="'.$API->app_path().'/questionnaire_questions/">', '</a>');
-        $details = $Question->to_array();
-        if (isset($details['options'])) {
-            $opts = PerchUtil::json_safe_decode($details['options'], true);
-            if (is_array($opts)) {
-                $lines = [];
-                foreach($opts as $k=>$v) $lines[] = $k.':'.$v;
-                $details['options'] = implode("\n", $lines);
+        if ($dependencies_valid) {
+            if ($Question) {
+                $Question->update($data);
+            } else {
+                $Question = $Questions->create($data);
             }
+            $message = $HTML->success_message('Question has been successfully saved. Return to %squestion listing%s', '<a href="'.$API->app_path().'/questionnaire_questions/">', '</a>');
+            $details = $Question->to_array();
+            if (isset($details['options'])) {
+                $opts = PerchUtil::json_safe_decode($details['options'], true);
+                if (is_array($opts)) {
+                    $lines = [];
+                    foreach($opts as $k=>$v) $lines[] = $k.':'.$v;
+                    $details['options'] = implode("\n", $lines);
+                }
+            }
+            if (isset($details['dependencies']) && $details['dependencies'] !== '') {
+                $deps = PerchUtil::json_safe_decode($details['dependencies'], true);
+                if (is_array($deps)) {
+                    $details['dependencies'] = PerchUtil::json_safe_encode($deps, true);
+                }
+            }
+        } else {
+            $details = array_merge($details, $data);
+            $details['options'] = $options_input;
+            $details['dependencies'] = $dependencies_input;
         }
     }
 ?>

--- a/perch/addons/apps/perch_members/modes/questions.flowchart.post.php
+++ b/perch/addons/apps/perch_members/modes/questions.flowchart.post.php
@@ -1,0 +1,160 @@
+<?php
+    echo $HTML->title_panel([
+        'heading' => $Lang->get('Questionnaire flowchart'),
+        'button'  => [
+            'text' => $Lang->get('Add question'),
+            'link' => '../edit/',
+            'icon' => 'add',
+            'priv' => 'perch_members.questionnaires.manage',
+        ],
+    ], $CurrentUser);
+
+    if ($message) echo $message;
+
+    $Smartbar = new PerchSmartbar($CurrentUser, $HTML, $Lang);
+    $Smartbar->add_item([
+        'active' => false,
+        'title'  => $Lang->get('Questions'),
+        'link'   => $API->app_nav().'/questionnaire_questions/',
+    ]);
+    $Smartbar->add_item([
+        'active' => true,
+        'title'  => $Lang->get('Flowchart'),
+        'link'   => $API->app_nav().'/questionnaire_questions/flowchart/',
+    ]);
+
+    echo $Smartbar->render();
+
+    echo '<div class="flowchart-toolbar">';
+        echo '<div class="flowchart-toolbar__tabs">';
+        foreach ($flowchart_types as $type => $label) {
+            $tab_classes = 'flowchart-toolbar__tab';
+            if ($type === $active_type) {
+                $tab_classes .= ' is-active';
+            }
+            $url = '?type='.urlencode($type);
+            echo '<a class="'.$tab_classes.'" href="'.$HTML->encode($url).'" data-flowchart-tab="'.$HTML->encode($type).'">'.$HTML->encode($label).'</a>';
+        }
+        echo '</div>';
+        echo '<p class="flowchart-toolbar__hint">'.$HTML->encode($Lang->get('Arrows indicate how answers reveal subsequent steps. Click a card to edit the question.')).'</p>';
+    echo '</div>';
+
+    echo '<div class="flowchart-legend">';
+        echo '<span class="flowchart-legend__item"><span class="flowchart-legend__swatch"></span>'.$HTML->encode($Lang->get('Dependency connection')).'</span>';
+        echo '<span class="flowchart-legend__note">'.$HTML->encode($Lang->get('Answer values appear beside each arrow.')).'</span>';
+    echo '</div>';
+
+    echo '<div class="questionnaire-flowchart" data-flowchart data-active-type="'.$HTML->encode($active_type).'">';
+
+    foreach ($flowchart_types as $type => $label) {
+        $is_active = ($type === $active_type) ? ' is-active' : '';
+        echo '<section class="flowchart-canvas'.$is_active.'" data-flowchart-canvas="'.$HTML->encode($type).'">';
+
+        $json = isset($flowchart_payload[$type]) ? PerchUtil::json_safe_encode($flowchart_payload[$type]) : '{}';
+        if ($json === false) {
+            $json = '{}';
+        }
+        echo '<script type="application/json" class="js-flowchart-data">'.$json.'</script>';
+
+        if (!PerchUtil::count($flowchart_data[$type]['steps'])) {
+            echo '<div class="flowchart-empty">'.$HTML->encode($Lang->get('No questions found for this questionnaire type yet.')).'</div>';
+        } else {
+            echo '<div class="flowchart-grid">';
+            foreach ($flowchart_data[$type]['steps'] as $step_slug => $step_data) {
+                echo '<div class="flowchart-step" data-step-slug="'.$HTML->encode($step_slug).'">';
+                    echo '<header class="flowchart-step__header">';
+                        echo '<span class="flowchart-step__title">'.$HTML->encode($step_slug).'</span>';
+                    echo '</header>';
+
+                    echo '<div class="flowchart-step__questions">';
+                    foreach ($step_data['questions'] as $question_key) {
+                        if (!isset($flowchart_data[$type]['questions'][$question_key])) continue;
+
+                        $question = $flowchart_data[$type]['questions'][$question_key];
+                        $field_name = $question['fieldName'];
+                        if ($field_name === '' || $field_name === null) {
+                            $field_name = $question['key'];
+                        }
+                        $option_list = $question['options'];
+                        $option_summary = trim($question['optionSummary']);
+                        $dependencies = $question['dependencies'];
+                        $edit_url = $API->app_path().'/questionnaire_questions/edit/?id='.$question['id'];
+
+                        $aria_label = $Lang->get('Edit question').' – '.$question['label'];
+                        echo '<article class="flowchart-node" data-question-key="'.$HTML->encode($question['key']).'" data-question-id="'.$HTML->encode((string)$question['id']).'" data-edit-url="'.$HTML->encode($edit_url).'" tabindex="0" role="link" aria-label="'.$HTML->encode($aria_label).'">';
+                            echo '<header class="flowchart-node__header">';
+                                echo '<h3 class="flowchart-node__title">'.$HTML->encode($question['label']).'</h3>';
+                            echo '</header>';
+
+                            echo '<div class="flowchart-node__meta">';
+                                echo '<dl>';
+                                    echo '<div class="flowchart-node__meta-row"><dt>'.$HTML->encode($Lang->get('Key')).'</dt><dd>'.$HTML->encode($question['key']).'</dd></div>';
+                                    echo '<div class="flowchart-node__meta-row"><dt>'.$HTML->encode($Lang->get('Field')).'</dt><dd>'.$HTML->encode($field_name).'</dd></div>';
+                                    echo '<div class="flowchart-node__meta-row"><dt>'.$HTML->encode($Lang->get('Type')).'</dt><dd>'.$HTML->encode($question['type']).'</dd></div>';
+                                    echo '<div class="flowchart-node__meta-row"><dt>'.$HTML->encode($Lang->get('Order')).'</dt><dd>'.$HTML->encode((string)$question['sort']).'</dd></div>';
+                                echo '</dl>';
+                            echo '</div>';
+
+                            if ($option_summary !== '') {
+                                echo '<div class="flowchart-node__options">';
+                                    echo '<strong>'.$HTML->encode($Lang->get('Options')).'</strong>';
+                                    echo '<p>'.$HTML->encode($option_summary).'</p>';
+                                echo '</div>';
+                            } elseif (PerchUtil::count($option_list)) {
+                                $display_options = array_slice($option_list, 0, 5, true);
+                                echo '<div class="flowchart-node__options">';
+                                    echo '<strong>'.$HTML->encode($Lang->get('Options')).'</strong>';
+                                    echo '<ul>';
+                                        foreach ($display_options as $value => $label) {
+                                            if (is_array($label) && isset($label['label'])) {
+                                                $option_label = $label['label'];
+                                            } elseif (is_array($label)) {
+                                                $option_label = implode(' ', $label);
+                                            } else {
+                                                $option_label = $label;
+                                            }
+                                            echo '<li>'.$HTML->encode($option_label).' <span class="flowchart-node__option-value">'.$HTML->encode('['.$value.']').'</span></li>';
+                                        }
+                                        $option_count = PerchUtil::count($option_list);
+                                        if ($option_count > 5) {
+                                            $remaining = $option_count - 5;
+                                            echo '<li class="flowchart-node__option-more">'.$HTML->encode('+'.$remaining.' '.$Lang->get('more')).'</li>';
+                                        }
+                                    echo '</ul>';
+                                echo '</div>';
+                            }
+
+                            if (PerchUtil::count($dependencies)) {
+                                echo '<div class="flowchart-node__dependencies">';
+                                    echo '<strong>'.$HTML->encode($Lang->get('Dependencies')).'</strong>';
+                                    echo '<ul>';
+                                        foreach ($dependencies as $dependency) {
+                                            $values_label = PerchUtil::count($dependency['values']) ? implode(', ', $dependency['values']) : $Lang->get('Any value');
+                                            $target = $dependency['question'] ?: $dependency['step'];
+                                            if (!$target) {
+                                                $target = $Lang->get('Unknown target');
+                                            }
+                                            $target_label = $dependency['question'] ? $Lang->get('Question') : $Lang->get('Step');
+                                            echo '<li>'.$HTML->encode($values_label).' &rarr; '.$HTML->encode($target_label.': '.$target).'</li>';
+                                        }
+                                    echo '</ul>';
+                                echo '</div>';
+                            }
+
+                            echo '<footer class="flowchart-node__footer">';
+                                echo '<a class="flowchart-node__edit" href="'.$HTML->encode($edit_url).'">'.$HTML->encode($Lang->get('Edit question')).'</a>';
+                            echo '</footer>';
+                        echo '</article>';
+                    }
+                    echo '</div>';
+                echo '</div>';
+            }
+            echo '</div>';
+        }
+
+        echo '<svg class="flowchart-connections" aria-hidden="true"></svg>';
+        echo '</section>';
+    }
+
+    echo '</div>';
+?>

--- a/perch/addons/apps/perch_members/modes/questions.flowchart.pre.php
+++ b/perch/addons/apps/perch_members/modes/questions.flowchart.pre.php
@@ -1,0 +1,154 @@
+<?php
+    $message = false;
+    $Questions = new PerchMembers_QuestionnaireQuestions($API);
+
+    $flowchart_types = [
+        'first-order' => $Lang->get('First-order questionnaire'),
+        'reorder'     => $Lang->get('Re-order questionnaire'),
+    ];
+
+    $requested_type = PerchRequest::get('type');
+    if (!$requested_type || !isset($flowchart_types[$requested_type])) {
+        $requested_type = 'first-order';
+    }
+
+    $flowchart_data = [];
+    foreach ($flowchart_types as $type => $label) {
+        $flowchart_data[$type] = [
+            'label'     => $label,
+            'steps'     => [],
+            'questions' => [],
+        ];
+    }
+
+    $questions = $Questions->all();
+
+    if (PerchUtil::count($questions)) {
+        foreach ($questions as $Question) {
+            $type = $Question->questionnaireType();
+            if (!isset($flowchart_data[$type])) {
+                continue;
+            }
+
+            $question_key = $Question->questionKey();
+            if ($question_key === '') {
+                continue;
+            }
+
+            $step_slug = $Question->stepSlug();
+            if ($step_slug === '' || $step_slug === null) {
+                $step_slug = $question_key;
+            }
+
+            $dependencies = [];
+            $raw_dependencies = $Question->dependencies();
+            if ($raw_dependencies) {
+                $decoded_dependencies = PerchUtil::json_safe_decode($raw_dependencies, true);
+                if (is_array($decoded_dependencies)) {
+                    foreach ($decoded_dependencies as $rule) {
+                        if (!is_array($rule)) continue;
+
+                        $values = [];
+                        if (isset($rule['values'])) {
+                            if (is_array($rule['values'])) {
+                                foreach ($rule['values'] as $value) {
+                                    if ($value === null) continue;
+                                    $values[] = (string)$value;
+                                }
+                            } else {
+                                $values[] = (string)$rule['values'];
+                            }
+                        }
+
+                        $dependencies[] = [
+                            'values'   => $values,
+                            'question' => (isset($rule['question']) && $rule['question'] !== '') ? (string)$rule['question'] : null,
+                            'step'     => (isset($rule['step']) && $rule['step'] !== '') ? (string)$rule['step'] : null,
+                        ];
+                    }
+                }
+            }
+
+            $flowchart_data[$type]['questions'][$question_key] = [
+                'id'           => (int)$Question->id(),
+                'key'          => $question_key,
+                'label'        => $Question->label(),
+                'fieldName'    => $Question->fieldName(),
+                'step'         => $step_slug,
+                'type'         => $Question->type(),
+                'sort'         => (int)$Question->sort(),
+                'dependencies' => $dependencies,
+                'options'      => $Question->option_list(),
+                'optionSummary'=> $Question->option_summary(),
+            ];
+
+            if (!isset($flowchart_data[$type]['steps'][$step_slug])) {
+                $flowchart_data[$type]['steps'][$step_slug] = [
+                    'slug'      => $step_slug,
+                    'questions' => [],
+                    'sort'      => (int)$Question->sort(),
+                ];
+            }
+
+            $flowchart_data[$type]['steps'][$step_slug]['questions'][] = $question_key;
+
+            if (!isset($flowchart_data[$type]['steps'][$step_slug]['sort']) || $flowchart_data[$type]['steps'][$step_slug]['sort'] > (int)$Question->sort()) {
+                $flowchart_data[$type]['steps'][$step_slug]['sort'] = (int)$Question->sort();
+            }
+        }
+
+        foreach ($flowchart_data as $type => &$data) {
+            uasort($data['steps'], function ($a, $b) {
+                if ($a['sort'] === $b['sort']) {
+                    return strcmp($a['slug'], $b['slug']);
+                }
+
+                return ($a['sort'] < $b['sort']) ? -1 : 1;
+            });
+
+            foreach ($data['steps'] as &$step) {
+                usort($step['questions'], function ($a_key, $b_key) use ($data) {
+                    $a_sort = isset($data['questions'][$a_key]['sort']) ? $data['questions'][$a_key]['sort'] : 0;
+                    $b_sort = isset($data['questions'][$b_key]['sort']) ? $data['questions'][$b_key]['sort'] : 0;
+
+                    if ($a_sort === $b_sort) {
+                        return strcmp($a_key, $b_key);
+                    }
+
+                    return ($a_sort < $b_sort) ? -1 : 1;
+                });
+            }
+            unset($step);
+        }
+        unset($data);
+    }
+
+    if (!isset($flowchart_types[$requested_type])) {
+        $requested_type = key($flowchart_types);
+    }
+
+    if (!PerchUtil::count($flowchart_data[$requested_type]['steps'])) {
+        foreach ($flowchart_types as $type => $label) {
+            if (PerchUtil::count($flowchart_data[$type]['steps'])) {
+                $requested_type = $type;
+                break;
+            }
+        }
+    }
+
+    $active_type = $requested_type;
+
+    $flowchart_payload = [];
+    foreach ($flowchart_data as $type => $data) {
+        $flowchart_payload[$type] = [
+            'questions' => [],
+        ];
+
+        foreach ($data['questions'] as $key => $question) {
+            $flowchart_payload[$type]['questions'][$key] = [
+                'dependencies' => $question['dependencies'],
+                'step'         => $question['step'],
+            ];
+        }
+    }
+?>

--- a/perch/addons/apps/perch_members/modes/questions.list.post.php
+++ b/perch/addons/apps/perch_members/modes/questions.list.post.php
@@ -10,6 +10,20 @@
 
     if (isset($message)) echo $message;
 
+    $Smartbar = new PerchSmartbar($CurrentUser, $HTML, $Lang);
+    $Smartbar->add_item([
+        'active' => true,
+        'title'  => $Lang->get('Questions'),
+        'link'   => $API->app_nav().'/questionnaire_questions/',
+    ]);
+    $Smartbar->add_item([
+        'active' => false,
+        'title'  => $Lang->get('Flowchart'),
+        'link'   => $API->app_nav().'/questionnaire_questions/flowchart/',
+    ]);
+
+    echo $Smartbar->render();
+
     $Listing = new PerchAdminListing($CurrentUser, $HTML, $Lang, $Paging);
     $Listing->add_col([
             'title'     => 'Question',
@@ -35,6 +49,54 @@
             'title'     => $Lang->get('Answer type'),
             'value'     => 'type',
             'sort'      => 'type',
+        ]);
+
+    $Listing->add_col([
+            'title' => $Lang->get('Field name'),
+            'value' => function ($Question, $HTML, $Lang) {
+                $field = $Question->fieldName();
+                if ($field === null || $field === '') {
+                    $field = $Question->questionKey();
+                }
+
+                return $HTML->encode($field);
+            },
+            'sort'  => 'fieldName',
+        ]);
+
+    $Listing->add_col([
+            'title' => $Lang->get('Step'),
+            'value' => function ($Question, $HTML, $Lang) {
+                $step = $Question->stepSlug();
+                if ($step === null || $step === '') {
+                    return $HTML->encode('—');
+                }
+
+                return $HTML->encode($step);
+            },
+            'sort'  => 'stepSlug',
+        ]);
+
+    $Listing->add_col([
+            'title' => $Lang->get('Dependencies'),
+            'value' => function ($Question, $HTML, $Lang) {
+                $raw = $Question->dependencies();
+                if (!$raw) {
+                    return $HTML->encode('—');
+                }
+
+                $decoded = PerchUtil::json_safe_decode($raw, true);
+                if (!is_array($decoded)) {
+                    return $HTML->encode('—');
+                }
+
+                $count = PerchUtil::count($decoded);
+                if ($count === false || $count === 0) {
+                    return $HTML->encode('—');
+                }
+
+                return $HTML->encode((string)$count);
+            },
         ]);
 
     $Listing->add_col([

--- a/perch/addons/apps/perch_members/questionnaire_questions/flowchart/index.php
+++ b/perch/addons/apps/perch_members/questionnaire_questions/flowchart/index.php
@@ -1,0 +1,24 @@
+<?php
+    include('../../../../../core/inc/api.php');
+
+    $API  = new PerchAPI(1.0, 'perch_members');
+    $HTML = $API->get('HTML');
+    $Lang = $API->get('Lang');
+
+    include('../../PerchMembers_QuestionnaireQuestions.class.php');
+    include('../../PerchMembers_QuestionnaireQuestion.class.php');
+
+    $Perch->page_title = $Lang->get('Questionnaire flowchart');
+
+    $Perch->add_css($API->app_path().'/assets/css/questionnaire-flowchart.css');
+    $Perch->add_javascript($API->app_path().'/assets/js/questionnaire-flowchart.js');
+
+    include('../../modes/_subnav.php');
+    include('../../modes/questions.flowchart.pre.php');
+
+    include(PERCH_CORE . '/inc/top.php');
+
+    include('../../modes/questions.flowchart.post.php');
+
+    include(PERCH_CORE . '/inc/btm.php');
+?>


### PR DESCRIPTION
## Summary
- add an admin "Flowchart" view that groups questionnaire questions by step and renders dependency connections
- expose navigation and styling assets so admins can switch between the list and flowchart with interactive cards linking to the editor
- parse question metadata for the flowchart, including dependency validation and JSON payload for client-side rendering

## Testing
- php -l perch/addons/apps/perch_members/modes/_subnav.php
- php -l perch/addons/apps/perch_members/modes/questions.list.post.php
- php -l perch/addons/apps/perch_members/questionnaire_questions/flowchart/index.php
- php -l perch/addons/apps/perch_members/modes/questions.flowchart.pre.php
- php -l perch/addons/apps/perch_members/modes/questions.flowchart.post.php

------
https://chatgpt.com/codex/tasks/task_b_68ce5a3d52bc8324bbf273e1a2537311