### PR TITLE
Cover yes/no fallbacks in questionnaire flowchart

### DIFF
--- a/perch/addons/apps/perch_members/assets/css/questionnaire-flowchart.css
+++ b/perch/addons/apps/perch_members/assets/css/questionnaire-flowchart.css
@@ -1,0 +1,332 @@
+.questionnaire-flowchart {
+    position: relative;
+    margin-top: 1.5rem;
+}
+
+.flowchart-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 1rem 0 0.75rem;
+}
+
+.flowchart-toolbar__tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.flowchart-toolbar__tab {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid #ccd5ff;
+    background: #f3f5ff;
+    color: #1f2937;
+    font-size: 0.85rem;
+    text-decoration: none;
+    transition: all 0.2s ease;
+}
+
+.flowchart-toolbar__tab:hover {
+    background: #e4e9ff;
+    border-color: #a9b8ff;
+}
+
+.flowchart-toolbar__tab.is-active {
+    background: #3657ff;
+    border-color: #3657ff;
+    color: #ffffff;
+}
+
+.flowchart-toolbar__hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #4b5563;
+}
+
+.flowchart-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    margin-bottom: 0.75rem;
+    font-size: 0.82rem;
+    color: #475569;
+}
+
+.flowchart-legend__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.flowchart-legend__swatch {
+    width: 16px;
+    height: 10px;
+    background: linear-gradient(90deg, rgba(91,124,250,0.15), rgba(91,124,250,0.65));
+    border-radius: 6px;
+    border: 1px solid rgba(91,124,250,0.4);
+}
+
+.flowchart-legend__note {
+    opacity: 0.85;
+}
+
+.flowchart-canvas {
+    display: none;
+    position: relative;
+    background: #ffffff;
+    border: 1px solid #d8deeb;
+    border-radius: 8px;
+    padding: 1.5rem;
+    min-height: 340px;
+    overflow: auto;
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,0.8);
+}
+
+.flowchart-canvas.is-active {
+    display: block;
+}
+
+.flowchart-grid {
+    display: flex;
+    align-items: flex-start;
+    gap: 1.5rem;
+    min-width: 100%;
+}
+
+.flowchart-step {
+    flex: 0 0 260px;
+    min-width: 240px;
+    background: #f4f7ff;
+    border: 1px solid #c7d4fb;
+    border-radius: 8px;
+    padding: 1rem;
+    box-shadow: 0 4px 12px rgba(15,23,42,0.04);
+}
+
+.flowchart-step--virtual {
+    background: #f9faff;
+    border-style: dashed;
+    border-color: #d5defa;
+}
+
+.flowchart-step__header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.45rem;
+    border-bottom: 1px solid #bcc8f2;
+    padding-bottom: 0.45rem;
+    margin-bottom: 0.75rem;
+}
+
+.flowchart-step__index {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    background: #e0e7ff;
+    color: #4338ca;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+.flowchart-step__title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #253053;
+}
+
+.flowchart-step__questions {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.flowchart-step__empty {
+    margin: 0;
+    padding: 0.35rem 0;
+    font-size: 0.78rem;
+    color: #64748b;
+    font-style: italic;
+}
+
+.flowchart-node {
+    background: #ffffff;
+    border: 1px solid #c6d1f0;
+    border-radius: 8px;
+    padding: 0.85rem;
+    box-shadow: 0 2px 6px rgba(30,64,175,0.08);
+    transition: box-shadow 0.2s ease, border-color 0.2s ease;
+    position: relative;
+}
+
+.flowchart-node[data-edit-url] {
+    cursor: pointer;
+}
+
+.flowchart-node:hover {
+    border-color: #7c91ff;
+    box-shadow: 0 6px 20px rgba(30,64,175,0.12);
+}
+
+.flowchart-node__header {
+    margin-bottom: 0.5rem;
+}
+
+.flowchart-node__title {
+    margin: 0;
+    font-size: 0.95rem;
+    color: #1f2937;
+}
+
+.flowchart-node__meta dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.35rem 0.75rem;
+    font-size: 0.78rem;
+    color: #374151;
+}
+
+.flowchart-node__meta dt {
+    font-weight: 600;
+    color: #475569;
+}
+
+.flowchart-node__meta dd {
+    margin: 0;
+    color: #0f172a;
+    word-break: break-word;
+}
+
+.flowchart-node__options,
+.flowchart-node__dependencies,
+.flowchart-node__follow-steps {
+    margin-top: 0.7rem;
+    font-size: 0.78rem;
+    color: #1f2937;
+}
+
+.flowchart-node__options ul,
+.flowchart-node__dependencies ul,
+.flowchart-node__follow-steps ul {
+    margin: 0.4rem 0 0;
+    padding-left: 1.1rem;
+}
+
+.flowchart-node__options li,
+.flowchart-node__dependencies li,
+.flowchart-node__follow-steps li {
+    margin-bottom: 0.3rem;
+    line-height: 1.35;
+}
+
+.flowchart-node__option-value {
+    color: #64748b;
+    font-size: 0.75rem;
+}
+
+.flowchart-node__follow-step-answer {
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.flowchart-node__follow-step-answer--default {
+    background: #eef2ff;
+    border-radius: 999px;
+    padding: 0.05rem 0.45rem;
+    font-size: 0.72rem;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: #4338ca;
+}
+
+.flowchart-node__follow-step-arrow {
+    margin: 0 0.35rem;
+    color: #4c51bf;
+}
+
+.flowchart-node__follow-step-target {
+    color: #1f2937;
+}
+
+.flowchart-node__follow-step-order {
+    margin-left: 0.35rem;
+    color: #4338ca;
+    font-size: 0.74rem;
+    font-weight: 600;
+}
+
+.flowchart-node__follow-step-question {
+    display: block;
+    margin-left: 1.35rem;
+    color: #475569;
+    font-size: 0.74rem;
+}
+
+.flowchart-node__option-more {
+    color: #64748b;
+    font-style: italic;
+}
+
+.flowchart-node__footer {
+    margin-top: 0.75rem;
+    text-align: right;
+}
+
+.flowchart-node__edit {
+    font-size: 0.78rem;
+    color: #2563eb;
+    text-decoration: none;
+}
+
+.flowchart-node__edit:hover,
+.flowchart-node__edit:focus {
+    text-decoration: underline;
+}
+
+.flowchart-connections {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
+
+.flowchart-connection {
+    stroke: #5b7cfa;
+    stroke-width: 2;
+    fill: none;
+    opacity: 0.75;
+}
+
+.flowchart-connection__label {
+    fill: #1f2937;
+    font-size: 0.72rem;
+    text-anchor: middle;
+    dominant-baseline: middle;
+    paint-order: stroke;
+    stroke: #ffffff;
+    stroke-width: 3px;
+}
+
+.flowchart-empty {
+    padding: 1rem;
+    color: #6b7280;
+    font-size: 0.9rem;
+}
+
+@media (max-width: 960px) {
+    .flowchart-grid {
+        flex-direction: column;
+    }
+
+    .flowchart-step {
+        width: 100%;
+    }
+}

--- a/perch/addons/apps/perch_members/assets/js/questionnaire-flowchart.js
+++ b/perch/addons/apps/perch_members/assets/js/questionnaire-flowchart.js
@@ -1,0 +1,286 @@
+(function () {
+    var SVG_NS = 'http://www.w3.org/2000/svg';
+
+    function parseJSONScript(el) {
+        if (!el) return null;
+        try {
+            return JSON.parse(el.textContent || el.innerText || '{}');
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function ensureArrowMarker(svg) {
+        var existing = svg.querySelector('#flowchart-arrow');
+        if (existing) {
+            return 'flowchart-arrow';
+        }
+
+        var defs = document.createElementNS(SVG_NS, 'defs');
+        var marker = document.createElementNS(SVG_NS, 'marker');
+        marker.setAttribute('id', 'flowchart-arrow');
+        marker.setAttribute('viewBox', '0 0 10 10');
+        marker.setAttribute('refX', '9');
+        marker.setAttribute('refY', '5');
+        marker.setAttribute('markerWidth', '6');
+        marker.setAttribute('markerHeight', '6');
+        marker.setAttribute('orient', 'auto');
+
+        var path = document.createElementNS(SVG_NS, 'path');
+        path.setAttribute('d', 'M 0 0 L 10 5 L 0 10 z');
+        path.setAttribute('fill', '#5b7cfa');
+        path.setAttribute('opacity', '0.75');
+
+        marker.appendChild(path);
+        defs.appendChild(marker);
+        svg.appendChild(defs);
+
+        return 'flowchart-arrow';
+    }
+
+    function truncateLabel(label) {
+        if (!label) return '';
+        if (label.length <= 40) return label;
+        return label.slice(0, 37) + '\u2026';
+    }
+
+    function drawPath(svg, container, fromEl, toEl, label) {
+        if (!fromEl || !toEl) return;
+
+        var containerRect = container.getBoundingClientRect();
+        var fromRect = fromEl.getBoundingClientRect();
+        var toRect = toEl.getBoundingClientRect();
+
+        var scrollLeft = container.scrollLeft || 0;
+        var scrollTop = container.scrollTop || 0;
+
+        var startX = fromRect.left + fromRect.width / 2 - containerRect.left + scrollLeft;
+        var startY = fromRect.bottom - containerRect.top + scrollTop;
+        var endX = toRect.left + toRect.width / 2 - containerRect.left + scrollLeft;
+        var endY = toRect.top - containerRect.top + scrollTop;
+
+        if (startX === endX && startY === endY) {
+            return;
+        }
+
+        var controlX = (startX + endX) / 2;
+
+        var path = document.createElementNS(SVG_NS, 'path');
+        path.setAttribute('d', 'M ' + startX + ' ' + startY + ' C ' + controlX + ' ' + startY + ' ' + controlX + ' ' + endY + ' ' + endX + ' ' + endY);
+        path.setAttribute('class', 'flowchart-connection');
+        path.setAttribute('marker-end', 'url(#' + ensureArrowMarker(svg) + ')');
+        svg.appendChild(path);
+
+        if (label) {
+            var text = document.createElementNS(SVG_NS, 'text');
+            text.textContent = truncateLabel(label);
+            text.setAttribute('x', controlX);
+            text.setAttribute('y', (startY + endY) / 2);
+            text.setAttribute('class', 'flowchart-connection__label');
+            svg.appendChild(text);
+        }
+    }
+
+    function drawConnections(canvas) {
+        var svg = canvas.querySelector('.flowchart-connections');
+        if (!svg) return;
+
+        while (svg.firstChild) {
+            svg.removeChild(svg.firstChild);
+        }
+
+        var data = parseJSONScript(canvas.querySelector('.js-flowchart-data'));
+        if (!data || !data.questions) return;
+
+        var width = canvas.scrollWidth || canvas.clientWidth;
+        var height = canvas.scrollHeight || canvas.clientHeight;
+        svg.setAttribute('width', width);
+        svg.setAttribute('height', height);
+        svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+
+        var nodes = {};
+        var nodeEls = canvas.querySelectorAll('[data-question-key]');
+        Array.prototype.forEach.call(nodeEls, function (el) {
+            var key = el.getAttribute('data-question-key');
+            if (key) {
+                nodes[key] = el;
+            }
+        });
+
+        var steps = {};
+        var stepEls = canvas.querySelectorAll('[data-step-slug]');
+        Array.prototype.forEach.call(stepEls, function (el) {
+            var slug = el.getAttribute('data-step-slug');
+            if (slug) {
+                steps[slug] = el;
+            }
+        });
+
+        Object.keys(data.questions).forEach(function (key) {
+            var question = data.questions[key];
+            if (!question) return;
+
+            var fromEl = nodes[key];
+            if (!fromEl) return;
+
+            var connections = [];
+            if (Array.isArray(question.connections) && question.connections.length) {
+                connections = question.connections;
+            } else if (Array.isArray(question.dependencies) && question.dependencies.length) {
+                connections = question.dependencies;
+            }
+
+            connections.forEach(function (connection) {
+                if (!connection) return;
+
+                var target = null;
+                if (connection.question && nodes[connection.question]) {
+                    target = nodes[connection.question];
+                } else if (connection.step && steps[connection.step]) {
+                    target = steps[connection.step];
+                }
+
+                if (!target || target === fromEl) {
+                    return;
+                }
+
+                var label = '';
+                if (typeof connection.label === 'string' && connection.label.length) {
+                    label = connection.label;
+                } else if (Array.isArray(connection.displayValues) && connection.displayValues.length) {
+                    label = connection.displayValues.join(', ');
+                } else if (Array.isArray(connection.values) && connection.values.length) {
+                    label = connection.values.join(', ');
+                }
+
+                drawPath(svg, canvas, fromEl, target, label);
+            });
+        });
+    }
+
+    function setupNodeInteractions(container) {
+        var cards = container.querySelectorAll('.flowchart-node[data-edit-url]');
+        Array.prototype.forEach.call(cards, function (card) {
+            if (!card.hasAttribute('tabindex')) {
+                card.setAttribute('tabindex', '0');
+            }
+            if (!card.hasAttribute('role')) {
+                card.setAttribute('role', 'link');
+            }
+
+            card.addEventListener('click', function (event) {
+                if (event.defaultPrevented) return;
+                if (event.target && event.target.closest('a')) {
+                    return;
+                }
+                var url = card.getAttribute('data-edit-url');
+                if (url) {
+                    window.location.href = url;
+                }
+            });
+
+            card.addEventListener('keydown', function (event) {
+                if (event.target && event.target.closest('a')) {
+                    return;
+                }
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    var url = card.getAttribute('data-edit-url');
+                    if (url) {
+                        window.location.href = url;
+                    }
+                }
+            });
+        });
+    }
+
+    function initFlowchart(container) {
+        var canvases = container.querySelectorAll('[data-flowchart-canvas]');
+        if (!canvases.length) return;
+
+        var toggles = [];
+        if (container.parentNode) {
+            toggles = container.parentNode.querySelectorAll('[data-flowchart-tab]');
+        } else {
+            toggles = document.querySelectorAll('[data-flowchart-tab]');
+        }
+        var activeType = container.getAttribute('data-active-type');
+        if (!activeType && canvases[0]) {
+            activeType = canvases[0].getAttribute('data-flowchart-canvas');
+            container.setAttribute('data-active-type', activeType);
+        }
+
+        function updateActive(type) {
+            var found = false;
+            Array.prototype.forEach.call(canvases, function (canvas) {
+                var matches = canvas.getAttribute('data-flowchart-canvas') === type;
+                canvas.classList.toggle('is-active', matches);
+                if (matches) {
+                    found = true;
+                }
+            });
+            if (!found && canvases[0]) {
+                canvases[0].classList.add('is-active');
+                type = canvases[0].getAttribute('data-flowchart-canvas');
+            }
+            container.setAttribute('data-active-type', type);
+            Array.prototype.forEach.call(toggles, function (toggle) {
+                if (toggle.getAttribute('data-flowchart-tab')) {
+                    toggle.classList.toggle('is-active', toggle.getAttribute('data-flowchart-tab') === type);
+                }
+            });
+            requestAnimationFrame(renderConnections);
+        }
+
+        function renderConnections() {
+            Array.prototype.forEach.call(canvases, function (canvas) {
+                if (canvas.classList.contains('is-active')) {
+                    drawConnections(canvas);
+                }
+            });
+        }
+
+        Array.prototype.forEach.call(canvases, function (canvas) {
+            canvas.addEventListener('scroll', function () {
+                if (canvas.classList.contains('is-active')) {
+                    requestAnimationFrame(function () {
+                        drawConnections(canvas);
+                    });
+                }
+            });
+        });
+
+        Array.prototype.forEach.call(toggles, function (toggle) {
+            toggle.addEventListener('click', function (event) {
+                var targetType = toggle.getAttribute('data-flowchart-tab');
+                if (!targetType) return;
+                event.preventDefault();
+                updateActive(targetType);
+                var href = toggle.getAttribute('href');
+                if (href && window.history && typeof window.history.replaceState === 'function') {
+                    if (href.charAt(0) === '?') {
+                        var base = window.location.href.split('?')[0];
+                        window.history.replaceState({}, document.title, base + href);
+                    } else {
+                        window.history.replaceState({}, document.title, href);
+                    }
+                }
+            });
+        });
+
+        window.addEventListener('resize', function () {
+            requestAnimationFrame(renderConnections);
+        });
+
+        updateActive(activeType);
+        setupNodeInteractions(container);
+        renderConnections();
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var containers = document.querySelectorAll('[data-flowchart]');
+        Array.prototype.forEach.call(containers, function (container) {
+            initFlowchart(container);
+        });
+    });
+})();

--- a/perch/addons/apps/perch_members/modes/_subnav.php
+++ b/perch/addons/apps/perch_members/modes/_subnav.php
@@ -24,5 +24,6 @@
                 ['page'=>[
                                         'perch_members/questionnaire_questions',
                                         'perch_members/questionnaire_questions/edit',
+                                        'perch_members/questionnaire_questions/flowchart',
                         ], 'label'=>'Questionnaires',  'priv'=>'perch_members.questionnaires.manage'],
         ], $CurrentUser);

--- a/perch/addons/apps/perch_members/modes/questions.edit.post.php
+++ b/perch/addons/apps/perch_members/modes/questions.edit.post.php
@@ -16,6 +16,12 @@
 
         echo $Form->text_field('label', 'Label', isset($details['label'])?$details['label']:false);
 
+        echo $Form->hint($Lang->get('Leave blank to reuse the question key as the form field name.'));
+        echo $Form->text_field('fieldName', 'Form field name', isset($details['fieldName'])?$details['fieldName']:false);
+
+        echo $Form->hint($Lang->get('Defines the questionnaire step slug. Leave blank to reuse the question key.'));
+        echo $Form->text_field('stepSlug', 'Step slug', isset($details['stepSlug'])?$details['stepSlug']:false);
+
         echo $Form->select_field('type', 'Field type', [
             ['value'=>'text','label'=>'Text'],
             ['value'=>'textarea','label'=>'Textarea'],
@@ -26,6 +32,9 @@
         ], isset($details['type'])?$details['type']:'text');
 
         echo $Form->textarea_field('options', 'Options (value:label per line)', isset($details['options'])?$details['options']:'');
+
+        echo $Form->hint($Lang->get('Provide dependency rules as JSON. Each rule should include "values" and optionally "question" and "step" keys. Leave blank if not required.'));
+        echo $Form->textarea_field('dependencies', 'Dependencies (JSON)', isset($details['dependencies'])?$details['dependencies']:'', 'input-simple code');
 
         echo $Form->hint($Lang->get('Use numbers to control the question order shown to clients. Lower numbers display first; leave blank to add to the end.'));
         echo $Form->text_field('sort', 'Display order', isset($details['sort'])?$details['sort']:'');

--- a/perch/addons/apps/perch_members/modes/questions.edit.pre.php
+++ b/perch/addons/apps/perch_members/modes/questions.edit.pre.php
@@ -14,6 +14,12 @@
                 $details['options'] = implode("\n", $lines);
             }
         }
+        if (isset($details['dependencies']) && $details['dependencies'] !== '') {
+            $deps = PerchUtil::json_safe_decode($details['dependencies'], true);
+            if (is_array($deps)) {
+                $details['dependencies'] = PerchUtil::json_safe_encode($deps, true);
+            }
+        }
         $heading1 = $Lang->get('Editing question');
     } else {
         $Question = false;
@@ -26,12 +32,15 @@
     $Form->require_field('questionKey', 'Required');
 
     if ($Form->submitted()) {
-        $postvars = ['questionnaireType','questionKey','label','type','options','sort'];
+        $postvars = ['questionnaireType','questionKey','label','type','options','fieldName','stepSlug','dependencies','sort'];
         $data = $Form->receive($postvars);
+
+        $options_input = isset($data['options']) ? trim($data['options']) : '';
         if (isset($data['options'])) {
-            $opts = preg_split('/\r\n|\r|\n/', trim($data['options']));
+            $opts = preg_split('/\r\n|\r|\n/', $options_input);
             $json = [];
             foreach($opts as $line) {
+                $line = trim($line);
                 if ($line==='') continue;
                 $parts = explode(':', $line, 2);
                 if (count($parts)==2) {
@@ -40,7 +49,39 @@
                     $json[$line] = $line;
                 }
             }
-            $data['options'] = json_encode($json);
+            $data['options'] = PerchUtil::json_safe_encode($json);
+        }
+
+        $dependencies_input = isset($data['dependencies']) ? trim($data['dependencies']) : '';
+        $dependencies_valid = true;
+        if ($dependencies_input === '') {
+            $data['dependencies'] = null;
+        } else {
+            $decoded_dependencies = PerchUtil::json_safe_decode($dependencies_input, true);
+            if (!is_array($decoded_dependencies)) {
+                $dependencies_valid = false;
+                $Form->error = true;
+                $Form->messages['dependencies'] = $Lang->get('Dependencies must be valid JSON.');
+                $message = $HTML->failure_message($Lang->get('Dependencies must be valid JSON.'));
+            } else {
+                $encoded = PerchUtil::json_safe_encode($decoded_dependencies);
+                if ($encoded === false) {
+                    $dependencies_valid = false;
+                    $Form->error = true;
+                    $Form->messages['dependencies'] = $Lang->get('Dependencies must be valid JSON.');
+                    $message = $HTML->failure_message($Lang->get('Dependencies must be valid JSON.'));
+                } else {
+                    $data['dependencies'] = $encoded;
+                }
+            }
+        }
+
+        if (isset($data['fieldName']) && $data['fieldName'] === '') {
+            $data['fieldName'] = null;
+        }
+
+        if (isset($data['stepSlug']) && $data['stepSlug'] === '') {
+            $data['stepSlug'] = null;
         }
 
         if (!isset($data['sort']) || !is_numeric($data['sort'])) {
@@ -52,20 +93,32 @@
             }
         }
 
-        if ($Question) {
-            $Question->update($data);
-        } else {
-            $Question = $Questions->create($data);
-        }
-        $message = $HTML->success_message('Question has been successfully saved. Return to %squestion listing%s', '<a href="'.$API->app_path().'/questionnaire_questions/">', '</a>');
-        $details = $Question->to_array();
-        if (isset($details['options'])) {
-            $opts = PerchUtil::json_safe_decode($details['options'], true);
-            if (is_array($opts)) {
-                $lines = [];
-                foreach($opts as $k=>$v) $lines[] = $k.':'.$v;
-                $details['options'] = implode("\n", $lines);
+        if ($dependencies_valid) {
+            if ($Question) {
+                $Question->update($data);
+            } else {
+                $Question = $Questions->create($data);
             }
+            $message = $HTML->success_message('Question has been successfully saved. Return to %squestion listing%s', '<a href="'.$API->app_path().'/questionnaire_questions/">', '</a>');
+            $details = $Question->to_array();
+            if (isset($details['options'])) {
+                $opts = PerchUtil::json_safe_decode($details['options'], true);
+                if (is_array($opts)) {
+                    $lines = [];
+                    foreach($opts as $k=>$v) $lines[] = $k.':'.$v;
+                    $details['options'] = implode("\n", $lines);
+                }
+            }
+            if (isset($details['dependencies']) && $details['dependencies'] !== '') {
+                $deps = PerchUtil::json_safe_decode($details['dependencies'], true);
+                if (is_array($deps)) {
+                    $details['dependencies'] = PerchUtil::json_safe_encode($deps, true);
+                }
+            }
+        } else {
+            $details = array_merge($details, $data);
+            $details['options'] = $options_input;
+            $details['dependencies'] = $dependencies_input;
         }
     }
 ?>

--- a/perch/addons/apps/perch_members/modes/questions.flowchart.post.php
+++ b/perch/addons/apps/perch_members/modes/questions.flowchart.post.php
@@ -1,0 +1,263 @@
+<?php
+    echo $HTML->title_panel([
+        'heading' => $Lang->get('Questionnaire flowchart'),
+        'button'  => [
+            'text' => $Lang->get('Add question'),
+            'link' => '../edit/',
+            'icon' => 'add',
+            'priv' => 'perch_members.questionnaires.manage',
+        ],
+    ], $CurrentUser);
+
+    if ($message) echo $message;
+
+    $Smartbar = new PerchSmartbar($CurrentUser, $HTML, $Lang);
+    $Smartbar->add_item([
+        'active' => false,
+        'title'  => $Lang->get('Questions'),
+        'link'   => $API->app_nav().'/questionnaire_questions/',
+    ]);
+    $Smartbar->add_item([
+        'active' => true,
+        'title'  => $Lang->get('Flowchart'),
+        'link'   => $API->app_nav().'/questionnaire_questions/flowchart/',
+    ]);
+
+    echo $Smartbar->render();
+
+    echo '<div class="flowchart-toolbar">';
+        echo '<div class="flowchart-toolbar__tabs">';
+        foreach ($flowchart_types as $type => $label) {
+            $tab_classes = 'flowchart-toolbar__tab';
+            if ($type === $active_type) {
+                $tab_classes .= ' is-active';
+            }
+            $url = '?type='.urlencode($type);
+            echo '<a class="'.$tab_classes.'" href="'.$HTML->encode($url).'" data-flowchart-tab="'.$HTML->encode($type).'">'.$HTML->encode($label).'</a>';
+        }
+        echo '</div>';
+        echo '<p class="flowchart-toolbar__hint">'.$HTML->encode($Lang->get('Arrows indicate how answers reveal subsequent steps. Click a card to edit the question.')).'</p>';
+    echo '</div>';
+
+    echo '<div class="flowchart-legend">';
+        echo '<span class="flowchart-legend__item"><span class="flowchart-legend__swatch"></span>'.$HTML->encode($Lang->get('Dependency connection')).'</span>';
+        echo '<span class="flowchart-legend__note">'.$HTML->encode($Lang->get('Answer values appear beside each arrow.')).'</span>';
+    echo '</div>';
+
+    echo '<div class="questionnaire-flowchart" data-flowchart data-active-type="'.$HTML->encode($active_type).'">';
+
+    foreach ($flowchart_types as $type => $label) {
+        $is_active = ($type === $active_type) ? ' is-active' : '';
+        echo '<section class="flowchart-canvas'.$is_active.'" data-flowchart-canvas="'.$HTML->encode($type).'">';
+
+        $json = isset($flowchart_payload[$type]) ? PerchUtil::json_safe_encode($flowchart_payload[$type]) : '{}';
+        if ($json === false) {
+            $json = '{}';
+        }
+        echo '<script type="application/json" class="js-flowchart-data">'.$json.'</script>';
+
+        if (!PerchUtil::count($flowchart_data[$type]['steps'])) {
+            echo '<div class="flowchart-empty">'.$HTML->encode($Lang->get('No questions found for this questionnaire type yet.')).'</div>';
+        } else {
+            echo '<div class="flowchart-grid">';
+            foreach ($flowchart_data[$type]['steps'] as $step_slug => $step_data) {
+                $step_classes = 'flowchart-step';
+                if (!empty($step_data['isVirtual'])) {
+                    $step_classes .= ' flowchart-step--virtual';
+                }
+
+                echo '<div class="'.$step_classes.'" data-step-slug="'.$HTML->encode($step_slug).'">';
+                    echo '<header class="flowchart-step__header">';
+                        if (isset($step_data['order']) && $step_data['order']) {
+                            echo '<span class="flowchart-step__index">'.$HTML->encode('#'.(string)$step_data['order']).'</span>';
+                        }
+                        echo '<span class="flowchart-step__title">'.$HTML->encode($step_slug).'</span>';
+                    echo '</header>';
+
+                    echo '<div class="flowchart-step__questions">';
+                    if (!PerchUtil::count($step_data['questions'])) {
+                        if (!empty($step_data['isVirtual'])) {
+                            echo '<p class="flowchart-step__empty">'.$HTML->encode($Lang->get('No questions assigned to this step yet.')).'</p>';
+                        }
+                    }
+                    foreach ($step_data['questions'] as $question_key) {
+                        if (!isset($flowchart_data[$type]['questions'][$question_key])) continue;
+
+                        $question = $flowchart_data[$type]['questions'][$question_key];
+                        $field_name = $question['fieldName'];
+                        if ($field_name === '' || $field_name === null) {
+                            $field_name = $question['key'];
+                        }
+                        $option_list = $question['options'];
+                        $option_summary = trim($question['optionSummary']);
+                        $dependencies = $question['dependencies'];
+                        $follow_steps = isset($question['followSteps']) ? $question['followSteps'] : [];
+                        $edit_url = $API->app_path().'/questionnaire_questions/edit/?id='.$question['id'];
+
+                        $aria_label = $Lang->get('Edit question').' – '.$question['label'];
+                        echo '<article class="flowchart-node" data-question-key="'.$HTML->encode($question['key']).'" data-question-id="'.$HTML->encode((string)$question['id']).'" data-edit-url="'.$HTML->encode($edit_url).'" tabindex="0" role="link" aria-label="'.$HTML->encode($aria_label).'">';
+                            echo '<header class="flowchart-node__header">';
+                                echo '<h3 class="flowchart-node__title">'.$HTML->encode($question['label']).'</h3>';
+                            echo '</header>';
+
+                            echo '<div class="flowchart-node__meta">';
+                                echo '<dl>';
+                                    echo '<div class="flowchart-node__meta-row"><dt>'.$HTML->encode($Lang->get('Key')).'</dt><dd>'.$HTML->encode($question['key']).'</dd></div>';
+                                    echo '<div class="flowchart-node__meta-row"><dt>'.$HTML->encode($Lang->get('Field')).'</dt><dd>'.$HTML->encode($field_name).'</dd></div>';
+                                    echo '<div class="flowchart-node__meta-row"><dt>'.$HTML->encode($Lang->get('Type')).'</dt><dd>'.$HTML->encode($question['type']).'</dd></div>';
+                                    echo '<div class="flowchart-node__meta-row"><dt>'.$HTML->encode($Lang->get('Order')).'</dt><dd>'.$HTML->encode((string)$question['sort']).'</dd></div>';
+                                echo '</dl>';
+                            echo '</div>';
+
+                            if ($option_summary !== '') {
+                                echo '<div class="flowchart-node__options">';
+                                    echo '<strong>'.$HTML->encode($Lang->get('Options')).'</strong>';
+                                    echo '<p>'.$HTML->encode($option_summary).'</p>';
+                                echo '</div>';
+                            } elseif (PerchUtil::count($option_list)) {
+                                $display_options = array_slice($option_list, 0, 5, true);
+                                echo '<div class="flowchart-node__options">';
+                                    echo '<strong>'.$HTML->encode($Lang->get('Options')).'</strong>';
+                                    echo '<ul>';
+                                        foreach ($display_options as $value => $label) {
+                                            if (is_array($label) && isset($label['label'])) {
+                                                $option_label = $label['label'];
+                                            } elseif (is_array($label)) {
+                                                $option_label = implode(' ', $label);
+                                            } else {
+                                                $option_label = $label;
+                                            }
+                                            echo '<li>'.$HTML->encode($option_label).' <span class="flowchart-node__option-value">'.$HTML->encode('['.$value.']').'</span></li>';
+                                        }
+                                        $option_count = PerchUtil::count($option_list);
+                                        if ($option_count > 5) {
+                                            $remaining = $option_count - 5;
+                                            echo '<li class="flowchart-node__option-more">'.$HTML->encode('+'.$remaining.' '.$Lang->get('more')).'</li>';
+                                        }
+                                    echo '</ul>';
+                                echo '</div>';
+                            }
+
+                            if (PerchUtil::count($follow_steps)) {
+                                echo '<div class="flowchart-node__follow-steps">';
+                                    echo '<strong>'.$HTML->encode($Lang->get('Follow-up steps')).'</strong>';
+                                    echo '<ul>';
+                                        foreach ($follow_steps as $follow_step) {
+                                            $step_type = isset($follow_step['type']) ? $follow_step['type'] : 'dependency';
+                                            $answer_classes = 'flowchart-node__follow-step-answer';
+                                            if ($step_type === 'order') {
+                                                $answer_classes .= ' flowchart-node__follow-step-answer--default';
+                                            }
+
+                                            $display_values = [];
+                                            if (isset($follow_step['displayValues']) && is_array($follow_step['displayValues']) && PerchUtil::count($follow_step['displayValues'])) {
+                                                $display_values = $follow_step['displayValues'];
+                                            }
+
+                                            $values_label = '';
+                                            if (isset($follow_step['label']) && $follow_step['label'] !== '') {
+                                                $values_label = $follow_step['label'];
+                                            } elseif (PerchUtil::count($display_values)) {
+                                                $values_label = implode(', ', $display_values);
+                                                if ($step_type === 'order') {
+                                                    $values_label .= ' ('.$Lang->get('Default order').')';
+                                                }
+                                            } else {
+                                                if ($step_type === 'order') {
+                                                    $values_label = $Lang->get('Default order');
+                                                } else {
+                                                    $values_label = $Lang->get('Any value');
+                                                }
+                                            }
+
+                                            $step_label = (isset($follow_step['step']) && $follow_step['step'] !== '') ? $follow_step['step'] : $Lang->get('Unknown step');
+                                            $order_number = isset($follow_step['order']) ? $follow_step['order'] : null;
+                                            $question_text = null;
+                                            if (!empty($follow_step['question'])) {
+                                                $question_text = $Lang->get('Question').': '.$follow_step['question'];
+                                                if (!empty($follow_step['questionLabel'])) {
+                                                    $question_text .= ' – '.$follow_step['questionLabel'];
+                                                }
+                                            }
+
+                                            echo '<li>';
+                                                echo '<span class="'.$answer_classes.'">'.$HTML->encode($values_label).'</span>';
+                                                echo '<span class="flowchart-node__follow-step-arrow">&rarr;</span>';
+                                                echo '<span class="flowchart-node__follow-step-target">'.$HTML->encode($Lang->get('Step').': '.$step_label).'</span>';
+                                                if ($order_number !== null) {
+                                                    echo '<span class="flowchart-node__follow-step-order">'.$HTML->encode('#'.(string)$order_number).'</span>';
+                                                }
+                                                if ($question_text !== null) {
+                                                    echo '<span class="flowchart-node__follow-step-question">'.$HTML->encode($question_text).'</span>';
+                                                }
+                                            echo '</li>';
+                                        }
+                                    echo '</ul>';
+                                echo '</div>';
+                            }
+
+                            if (PerchUtil::count($dependencies)) {
+                                echo '<div class="flowchart-node__dependencies">';
+                                    echo '<strong>'.$HTML->encode($Lang->get('Dependencies')).'</strong>';
+                                    echo '<ul>';
+                                        foreach ($dependencies as $dependency) {
+                                            $display_values = [];
+                                            if (isset($dependency['valueLabels']) && is_array($dependency['valueLabels']) && PerchUtil::count($dependency['valueLabels'])) {
+                                                $display_values = $dependency['valueLabels'];
+                                            } elseif (isset($dependency['values']) && is_array($dependency['values']) && PerchUtil::count($dependency['values'])) {
+                                                $display_values = $dependency['values'];
+                                            }
+
+                                            $values_label = PerchUtil::count($display_values) ? implode(', ', $display_values) : $Lang->get('Any value');
+                                            $parts = [];
+
+                                            if (isset($dependency['resolvedStep']) && $dependency['resolvedStep']) {
+                                                $step_text = $Lang->get('Step').': '.$dependency['resolvedStep'];
+                                                if (isset($dependency['resolvedStepOrder']) && $dependency['resolvedStepOrder'] !== null) {
+                                                    $step_text .= ' (#'.$dependency['resolvedStepOrder'].')';
+                                                }
+                                                $parts[] = $step_text;
+                                            } elseif (!empty($dependency['step'])) {
+                                                $parts[] = $Lang->get('Step').': '.$dependency['step'];
+                                            }
+
+                                            if (!empty($dependency['question'])) {
+                                                $question_target = $Lang->get('Question').': '.$dependency['question'];
+                                                if (!empty($dependency['targetQuestionLabel'])) {
+                                                    $question_target .= ' – '.$dependency['targetQuestionLabel'];
+                                                }
+                                                $parts[] = $question_target;
+                                            }
+
+                                            if (!PerchUtil::count($parts)) {
+                                                $parts[] = $Lang->get('Unknown target');
+                                            }
+
+                                            $encoded_parts = [];
+                                            foreach ($parts as $part_text) {
+                                                $encoded_parts[] = $HTML->encode($part_text);
+                                            }
+
+                                            echo '<li>'.$HTML->encode($values_label).' &rarr; '.implode(' | ', $encoded_parts).'</li>';
+                                        }
+                                    echo '</ul>';
+                                echo '</div>';
+                            }
+
+                            echo '<footer class="flowchart-node__footer">';
+                                echo '<a class="flowchart-node__edit" href="'.$HTML->encode($edit_url).'">'.$HTML->encode($Lang->get('Edit question')).'</a>';
+                            echo '</footer>';
+                        echo '</article>';
+                    }
+                    echo '</div>';
+                echo '</div>';
+            }
+            echo '</div>';
+        }
+
+        echo '<svg class="flowchart-connections" aria-hidden="true"></svg>';
+        echo '</section>';
+    }
+
+    echo '</div>';
+?>

--- a/perch/addons/apps/perch_members/modes/questions.flowchart.pre.php
+++ b/perch/addons/apps/perch_members/modes/questions.flowchart.pre.php
@@ -1,0 +1,534 @@
+<?php
+    if (!function_exists('perch_members_flowchart_normalize_option_label')) {
+        function perch_members_flowchart_normalize_option_label($value, $option)
+        {
+            if (is_array($option)) {
+                if (isset($option['label'])) {
+                    $label = $option['label'];
+                } else {
+                    $parts = [];
+                    foreach ($option as $part) {
+                        if (is_scalar($part)) {
+                            $parts[] = (string)$part;
+                        }
+                    }
+                    $label = implode(' ', $parts);
+                }
+            } else {
+                $label = $option;
+            }
+
+            $label = trim((string)$label);
+
+            if ($label === '') {
+                $label = (string)$value;
+            }
+
+            return $label;
+        }
+    }
+
+    if (!function_exists('perch_members_flowchart_option_labels')) {
+        function perch_members_flowchart_option_labels($options)
+        {
+            $map = [];
+
+            if (!is_array($options) || !PerchUtil::count($options)) {
+                return $map;
+            }
+
+            foreach ($options as $value => $option) {
+                $candidates = [];
+
+                if (is_string($value) || is_numeric($value)) {
+                    $candidates[] = (string)$value;
+                }
+
+                if (is_array($option) && array_key_exists('value', $option)) {
+                    $candidate_value = $option['value'];
+                    if ($candidate_value !== null) {
+                        $candidates[] = (string)$candidate_value;
+                    }
+                }
+
+                if (!count($candidates)) {
+                    if (is_scalar($option)) {
+                        $candidates[] = (string)$option;
+                    }
+                }
+
+                $label = perch_members_flowchart_normalize_option_label($value, $option);
+
+                foreach ($candidates as $candidate) {
+                    $map[(string)$candidate] = $label;
+                }
+            }
+
+            return $map;
+        }
+    }
+
+    if (!function_exists('perch_members_flowchart_follow_label')) {
+        function perch_members_flowchart_follow_label($follow_step, $Lang)
+        {
+            $display_values = [];
+            if (isset($follow_step['displayValues']) && is_array($follow_step['displayValues']) && PerchUtil::count($follow_step['displayValues'])) {
+                $display_values = $follow_step['displayValues'];
+            }
+
+            $type = isset($follow_step['type']) ? $follow_step['type'] : 'dependency';
+
+            if (PerchUtil::count($display_values)) {
+                $label = implode(', ', $display_values);
+                if ($type === 'order') {
+                    $label .= ' ('.$Lang->get('Default order').')';
+                }
+                return $label;
+            }
+
+            if ($type === 'order') {
+                return $Lang->get('Default order');
+            }
+
+            return $Lang->get('Any value');
+        }
+    }
+
+    $message = false;
+    $Questions = new PerchMembers_QuestionnaireQuestions($API);
+
+    $flowchart_types = [
+        'first-order' => $Lang->get('First-order questionnaire'),
+        'reorder'     => $Lang->get('Re-order questionnaire'),
+    ];
+
+    $requested_type = PerchRequest::get('type');
+    if (!$requested_type || !isset($flowchart_types[$requested_type])) {
+        $requested_type = 'first-order';
+    }
+
+    $flowchart_data = [];
+    $pending_steps = [];
+    foreach ($flowchart_types as $type => $label) {
+        $flowchart_data[$type] = [
+            'label'     => $label,
+            'steps'     => [],
+            'questions' => [],
+        ];
+    }
+
+    $questions = $Questions->all();
+
+    if (PerchUtil::count($questions)) {
+        foreach ($questions as $Question) {
+            $type = $Question->questionnaireType();
+            if (!isset($flowchart_data[$type])) {
+                continue;
+            }
+
+            $question_key = $Question->questionKey();
+            if ($question_key === '') {
+                continue;
+            }
+
+            $step_slug = $Question->stepSlug();
+            if ($step_slug === '' || $step_slug === null) {
+                $step_slug = $question_key;
+            }
+
+            $dependencies = [];
+            $raw_dependencies = $Question->dependencies();
+            if ($raw_dependencies) {
+                $decoded_dependencies = PerchUtil::json_safe_decode($raw_dependencies, true);
+                if (is_array($decoded_dependencies)) {
+                    $dependency_index = 0;
+                    foreach ($decoded_dependencies as $rule) {
+                        if (!is_array($rule)) continue;
+
+                        $values = [];
+                        if (isset($rule['values'])) {
+                            if (is_array($rule['values'])) {
+                                foreach ($rule['values'] as $value) {
+                                    if ($value === null) continue;
+                                    $values[] = (string)$value;
+                                }
+                            } else {
+                                $values[] = (string)$rule['values'];
+                            }
+                        }
+
+                        $target_question = (isset($rule['question']) && $rule['question'] !== '') ? (string)$rule['question'] : null;
+                        $target_step     = (isset($rule['step']) && $rule['step'] !== '') ? (string)$rule['step'] : null;
+
+                        if ($target_step) {
+                            if (!isset($pending_steps[$type])) {
+                                $pending_steps[$type] = [];
+                            }
+                            if (!isset($pending_steps[$type][$target_step])) {
+                                $pending_steps[$type][$target_step] = [];
+                            }
+                            $pending_steps[$type][$target_step][] = [
+                                'source_sort'     => (float)$Question->sort(),
+                                'source_question' => $question_key,
+                                'source_step'     => $step_slug,
+                            ];
+                        }
+
+                        $dependencies[] = [
+                            'values'   => $values,
+                            'question' => $target_question,
+                            'step'     => $target_step,
+                            'index'    => $dependency_index++,
+                        ];
+                    }
+                }
+            }
+
+            $flowchart_data[$type]['questions'][$question_key] = [
+                'id'           => (int)$Question->id(),
+                'key'          => $question_key,
+                'label'        => $Question->label(),
+                'fieldName'    => $Question->fieldName(),
+                'step'         => $step_slug,
+                'type'         => $Question->type(),
+                'sort'         => (int)$Question->sort(),
+                'dependencies' => $dependencies,
+                'followSteps'  => [],
+                'connections'  => [],
+                'options'      => $Question->option_list(),
+                'optionSummary'=> $Question->option_summary(),
+            ];
+
+            if (!isset($flowchart_data[$type]['steps'][$step_slug])) {
+                $flowchart_data[$type]['steps'][$step_slug] = [
+                    'slug'      => $step_slug,
+                    'questions' => [],
+                    'sort'      => (float)$Question->sort(),
+                    'order'     => null,
+                    'isVirtual' => false,
+                ];
+            }
+
+            $flowchart_data[$type]['steps'][$step_slug]['questions'][] = $question_key;
+
+            if (!isset($flowchart_data[$type]['steps'][$step_slug]['sort']) || $flowchart_data[$type]['steps'][$step_slug]['sort'] > (float)$Question->sort()) {
+                $flowchart_data[$type]['steps'][$step_slug]['sort'] = (float)$Question->sort();
+            }
+        }
+
+        if (!empty($pending_steps)) {
+            foreach ($pending_steps as $type => $step_sources) {
+                if (!isset($flowchart_data[$type])) continue;
+
+                foreach ($step_sources as $step_slug => $sources) {
+                    if (isset($flowchart_data[$type]['steps'][$step_slug])) continue;
+
+                    $min_sort = null;
+                    if (is_array($sources)) {
+                        foreach ($sources as $source) {
+                            if (!is_array($source)) continue;
+                            $source_sort = isset($source['source_sort']) ? (float)$source['source_sort'] : null;
+                            if ($source_sort === null) continue;
+
+                            $adjusted = $source_sort + 0.25;
+                            if ($min_sort === null || $adjusted < $min_sort) {
+                                $min_sort = $adjusted;
+                            }
+                        }
+                    }
+
+                    if ($min_sort === null) {
+                        $min_sort = 0.0;
+                    }
+
+                    $flowchart_data[$type]['steps'][$step_slug] = [
+                        'slug'      => $step_slug,
+                        'questions' => [],
+                        'sort'      => $min_sort,
+                        'order'     => null,
+                        'isVirtual' => true,
+                    ];
+                }
+            }
+        }
+
+        foreach ($flowchart_data as $type => &$data) {
+            uasort($data['steps'], function ($a, $b) {
+                $a_sort = isset($a['sort']) ? $a['sort'] : 0;
+                $b_sort = isset($b['sort']) ? $b['sort'] : 0;
+
+                if ($a_sort === $b_sort) {
+                    $a_slug = isset($a['slug']) ? $a['slug'] : '';
+                    $b_slug = isset($b['slug']) ? $b['slug'] : '';
+                    return strcmp($a_slug, $b_slug);
+                }
+
+                return ($a_sort < $b_sort) ? -1 : 1;
+            });
+
+            $step_order_map = [];
+            $step_position = 1;
+            foreach ($data['steps'] as $slug => &$step) {
+                if (!isset($step['questions']) || !is_array($step['questions'])) {
+                    $step['questions'] = [];
+                }
+
+                usort($step['questions'], function ($a_key, $b_key) use ($data) {
+                    $a_sort = isset($data['questions'][$a_key]['sort']) ? $data['questions'][$a_key]['sort'] : 0;
+                    $b_sort = isset($data['questions'][$b_key]['sort']) ? $data['questions'][$b_key]['sort'] : 0;
+
+                    if ($a_sort === $b_sort) {
+                        return strcmp($a_key, $b_key);
+                    }
+
+                    return ($a_sort < $b_sort) ? -1 : 1;
+                });
+
+                $step['order'] = $step_position;
+                $step_order_map[$slug] = $step_position;
+                $step_position++;
+            }
+            unset($step);
+
+            $question_sequence = [];
+            foreach ($data['questions'] as $question_key => $question_details) {
+                $question_sequence[] = [
+                    'key'  => $question_key,
+                    'sort' => isset($question_details['sort']) ? (float)$question_details['sort'] : 0.0,
+                ];
+            }
+
+            usort($question_sequence, function ($a, $b) {
+                if ($a['sort'] === $b['sort']) {
+                    return strcmp($a['key'], $b['key']);
+                }
+
+                return ($a['sort'] < $b['sort']) ? -1 : 1;
+            });
+
+            $default_paths = [];
+            $sequence_count = PerchUtil::count($question_sequence);
+            if ($sequence_count) {
+                for ($i = 0; $i < $sequence_count; $i++) {
+                    $current = $question_sequence[$i];
+                    $next = ($i + 1 < $sequence_count) ? $question_sequence[$i + 1] : null;
+                    if (!$next) {
+                        continue;
+                    }
+
+                    $next_key = $next['key'];
+                    $default_paths[$current['key']] = [
+                        'next_question' => $next_key,
+                        'next_step'     => isset($data['questions'][$next_key]) ? $data['questions'][$next_key]['step'] : null,
+                    ];
+                }
+            }
+
+            foreach ($data['questions'] as $question_key => &$question) {
+                $dependencies = isset($question['dependencies']) && is_array($question['dependencies']) ? $question['dependencies'] : [];
+                $follow_steps = [];
+
+                $option_labels = [];
+                if (isset($question['options'])) {
+                    $option_labels = perch_members_flowchart_option_labels($question['options']);
+                }
+
+                $covered_values = [];
+                $covers_all_values = false;
+
+                foreach ($dependencies as &$dependency) {
+                    $resolved_step = null;
+                    $resolved_order = null;
+                    $target_question_label = null;
+                    $target_question_sort = null;
+
+                    $dependency_values = isset($dependency['values']) && is_array($dependency['values']) ? $dependency['values'] : [];
+                    $normalized_values = [];
+                    $display_values = [];
+
+                    if (PerchUtil::count($dependency_values)) {
+                        foreach ($dependency_values as $value) {
+                            if ($value === null) continue;
+                            $value_key = (string)$value;
+                            if (!in_array($value_key, $normalized_values, true)) {
+                                $normalized_values[] = $value_key;
+                            }
+                            $covered_values[$value_key] = true;
+                            if (isset($option_labels[$value_key])) {
+                                $display_values[] = $option_labels[$value_key];
+                            } else {
+                                $display_values[] = $value_key;
+                            }
+                        }
+                    } else {
+                        $covers_all_values = true;
+                    }
+
+                    $dependency['values'] = $normalized_values;
+                    $dependency['valueLabels'] = $display_values;
+
+                    $target_question_key = isset($dependency['question']) ? $dependency['question'] : null;
+                    if ($target_question_key && isset($data['questions'][$target_question_key])) {
+                        $target_question = $data['questions'][$target_question_key];
+                        if (isset($target_question['step']) && $target_question['step'] !== '') {
+                            $resolved_step = $target_question['step'];
+                        }
+                        $target_question_label = isset($target_question['label']) ? $target_question['label'] : null;
+                        $target_question_sort = isset($target_question['sort']) ? $target_question['sort'] : null;
+                    }
+
+                    if (isset($dependency['step']) && $dependency['step'] !== null && $dependency['step'] !== '') {
+                        $resolved_step = $dependency['step'];
+                    }
+
+                    if ($resolved_step && isset($step_order_map[$resolved_step])) {
+                        $resolved_order = $step_order_map[$resolved_step];
+                    }
+
+                    $dependency['resolvedStep'] = $resolved_step;
+                    $dependency['resolvedStepOrder'] = $resolved_order;
+                    $dependency['targetQuestionLabel'] = $target_question_label;
+                    $dependency['targetQuestionSort'] = $target_question_sort;
+
+                    $follow_step = [
+                        'values'        => $normalized_values,
+                        'displayValues' => $display_values,
+                        'step'          => $resolved_step,
+                        'order'         => $resolved_order,
+                        'question'      => $target_question_key,
+                        'questionLabel' => $target_question_label,
+                        'type'          => 'dependency',
+                        'index'         => isset($dependency['index']) ? $dependency['index'] : null,
+                    ];
+                    $follow_step['label'] = perch_members_flowchart_follow_label($follow_step, $Lang);
+                    $follow_steps[] = $follow_step;
+                }
+                unset($dependency);
+
+                if (isset($default_paths[$question_key])) {
+                    $default = $default_paths[$question_key];
+                    $default_step = isset($default['next_step']) ? $default['next_step'] : null;
+                    $default_question_key = isset($default['next_question']) ? $default['next_question'] : null;
+                    $default_question_label = ($default_question_key && isset($data['questions'][$default_question_key]['label'])) ? $data['questions'][$default_question_key]['label'] : null;
+                    $default_order = ($default_step && isset($step_order_map[$default_step])) ? $step_order_map[$default_step] : null;
+
+                    $default_values = [];
+                    $default_display_values = [];
+
+                    if (!$covers_all_values && PerchUtil::count($option_labels)) {
+                        foreach ($option_labels as $value_key => $label_text) {
+                            if (!isset($covered_values[$value_key])) {
+                                if (!in_array($value_key, $default_values, true)) {
+                                    $default_values[] = $value_key;
+                                }
+                                if (!in_array($label_text, $default_display_values, true)) {
+                                    $default_display_values[] = $label_text;
+                                }
+                            }
+                        }
+                    }
+
+                    $follow_step = [
+                        'values'        => $default_values,
+                        'displayValues' => $default_display_values,
+                        'step'          => $default_step,
+                        'order'         => $default_order,
+                        'question'      => $default_question_key,
+                        'questionLabel' => $default_question_label,
+                        'type'          => 'order',
+                        'index'         => null,
+                    ];
+                    $follow_step['label'] = perch_members_flowchart_follow_label($follow_step, $Lang);
+                    $follow_steps[] = $follow_step;
+                }
+
+                if (PerchUtil::count($follow_steps)) {
+                    usort($follow_steps, function ($a, $b) {
+                        $a_weight = ($a['type'] === 'order') ? 1 : 0;
+                        $b_weight = ($b['type'] === 'order') ? 1 : 0;
+                        if ($a_weight !== $b_weight) {
+                            return ($a_weight < $b_weight) ? -1 : 1;
+                        }
+
+                        $a_order = isset($a['order']) ? $a['order'] : null;
+                        $b_order = isset($b['order']) ? $b['order'] : null;
+                        if ($a_order !== $b_order) {
+                            if ($a_order === null) return 1;
+                            if ($b_order === null) return -1;
+                            return ($a_order < $b_order) ? -1 : 1;
+                        }
+
+                        if ($a['type'] === 'dependency' && $b['type'] === 'dependency') {
+                            $a_index = isset($a['index']) ? $a['index'] : 0;
+                            $b_index = isset($b['index']) ? $b['index'] : 0;
+                            if ($a_index !== $b_index) {
+                                return ($a_index < $b_index) ? -1 : 1;
+                            }
+                        }
+
+                        $a_step = isset($a['step']) ? $a['step'] : '';
+                        $b_step = isset($b['step']) ? $b['step'] : '';
+                        return strcmp($a_step, $b_step);
+                    });
+                }
+
+                $connections = [];
+                if (PerchUtil::count($follow_steps)) {
+                    foreach ($follow_steps as $follow_step_item) {
+                        $target_question_key = isset($follow_step_item['question']) ? $follow_step_item['question'] : null;
+                        $target_step = isset($follow_step_item['step']) ? $follow_step_item['step'] : null;
+
+                        if ($target_question_key === null && ($target_step === null || $target_step === '')) {
+                            continue;
+                        }
+
+                        $connections[] = [
+                            'question'      => $target_question_key,
+                            'step'          => $target_step,
+                            'type'          => isset($follow_step_item['type']) ? $follow_step_item['type'] : 'dependency',
+                            'label'         => isset($follow_step_item['label']) ? $follow_step_item['label'] : null,
+                            'values'        => isset($follow_step_item['values']) ? $follow_step_item['values'] : [],
+                            'displayValues' => isset($follow_step_item['displayValues']) ? $follow_step_item['displayValues'] : [],
+                        ];
+                    }
+                }
+
+                $question['followSteps'] = $follow_steps;
+                $question['connections'] = $connections;
+                $question['dependencies'] = $dependencies;
+            }
+            unset($question);
+        }
+        unset($data);
+    }
+
+    if (!isset($flowchart_types[$requested_type])) {
+        $requested_type = key($flowchart_types);
+    }
+
+    if (!PerchUtil::count($flowchart_data[$requested_type]['steps'])) {
+        foreach ($flowchart_types as $type => $label) {
+            if (PerchUtil::count($flowchart_data[$type]['steps'])) {
+                $requested_type = $type;
+                break;
+            }
+        }
+    }
+
+    $active_type = $requested_type;
+
+    $flowchart_payload = [];
+    foreach ($flowchart_data as $type => $data) {
+        $flowchart_payload[$type] = [
+            'questions' => [],
+        ];
+
+        foreach ($data['questions'] as $key => $question) {
+            $flowchart_payload[$type]['questions'][$key] = [
+                'dependencies' => $question['dependencies'],
+                'connections'  => isset($question['connections']) ? $question['connections'] : [],
+                'step'         => $question['step'],
+            ];
+        }
+    }
+?>

--- a/perch/addons/apps/perch_members/modes/questions.list.post.php
+++ b/perch/addons/apps/perch_members/modes/questions.list.post.php
@@ -10,6 +10,20 @@
 
     if (isset($message)) echo $message;
 
+    $Smartbar = new PerchSmartbar($CurrentUser, $HTML, $Lang);
+    $Smartbar->add_item([
+        'active' => true,
+        'title'  => $Lang->get('Questions'),
+        'link'   => $API->app_nav().'/questionnaire_questions/',
+    ]);
+    $Smartbar->add_item([
+        'active' => false,
+        'title'  => $Lang->get('Flowchart'),
+        'link'   => $API->app_nav().'/questionnaire_questions/flowchart/',
+    ]);
+
+    echo $Smartbar->render();
+
     $Listing = new PerchAdminListing($CurrentUser, $HTML, $Lang, $Paging);
     $Listing->add_col([
             'title'     => 'Question',
@@ -35,6 +49,54 @@
             'title'     => $Lang->get('Answer type'),
             'value'     => 'type',
             'sort'      => 'type',
+        ]);
+
+    $Listing->add_col([
+            'title' => $Lang->get('Field name'),
+            'value' => function ($Question, $HTML, $Lang) {
+                $field = $Question->fieldName();
+                if ($field === null || $field === '') {
+                    $field = $Question->questionKey();
+                }
+
+                return $HTML->encode($field);
+            },
+            'sort'  => 'fieldName',
+        ]);
+
+    $Listing->add_col([
+            'title' => $Lang->get('Step'),
+            'value' => function ($Question, $HTML, $Lang) {
+                $step = $Question->stepSlug();
+                if ($step === null || $step === '') {
+                    return $HTML->encode('—');
+                }
+
+                return $HTML->encode($step);
+            },
+            'sort'  => 'stepSlug',
+        ]);
+
+    $Listing->add_col([
+            'title' => $Lang->get('Dependencies'),
+            'value' => function ($Question, $HTML, $Lang) {
+                $raw = $Question->dependencies();
+                if (!$raw) {
+                    return $HTML->encode('—');
+                }
+
+                $decoded = PerchUtil::json_safe_decode($raw, true);
+                if (!is_array($decoded)) {
+                    return $HTML->encode('—');
+                }
+
+                $count = PerchUtil::count($decoded);
+                if ($count === false || $count === 0) {
+                    return $HTML->encode('—');
+                }
+
+                return $HTML->encode((string)$count);
+            },
         ]);
 
     $Listing->add_col([

--- a/perch/addons/apps/perch_members/questionnaire_questions/flowchart/index.php
+++ b/perch/addons/apps/perch_members/questionnaire_questions/flowchart/index.php
@@ -1,0 +1,24 @@
+<?php
+    include('../../../../../core/inc/api.php');
+
+    $API  = new PerchAPI(1.0, 'perch_members');
+    $HTML = $API->get('HTML');
+    $Lang = $API->get('Lang');
+
+    include('../../PerchMembers_QuestionnaireQuestions.class.php');
+    include('../../PerchMembers_QuestionnaireQuestion.class.php');
+
+    $Perch->page_title = $Lang->get('Questionnaire flowchart');
+
+    $Perch->add_css($API->app_path().'/assets/css/questionnaire-flowchart.css');
+    $Perch->add_javascript($API->app_path().'/assets/js/questionnaire-flowchart.js');
+
+    include('../../modes/_subnav.php');
+    include('../../modes/questions.flowchart.pre.php');
+
+    include(PERCH_CORE . '/inc/top.php');
+
+    include('../../modes/questions.flowchart.post.php');
+
+    include(PERCH_CORE . '/inc/btm.php');
+?>


### PR DESCRIPTION
## Summary
- normalise questionnaire option labels and compute follow-step connections that include uncovered default answer paths
- surface the new follow-up metadata within the admin flowchart cards and dependency lists for clearer yes/no routing
- update the flowchart canvas script to render connectors for both dependency-driven and default-order paths

## Testing
- php -l perch/addons/apps/perch_members/modes/questions.flowchart.pre.php
- php -l perch/addons/apps/perch_members/modes/questions.flowchart.post.php

------
https://chatgpt.com/codex/tasks/task_b_68ce5a3d52bc8324bbf273e1a2537311