### PR TITLE
Link questionnaire responses to orders when sending to pharmacy

### DIFF
--- a/perch/addons/apps/api/routes/add_member_questions.php
+++ b/perch/addons/apps/api/routes/add_member_questions.php
@@ -41,7 +41,11 @@
        if(isset($data['questionnaire']) && !empty($data['questionnaire'])){
          $data['questionnaire']["documents"]="https://getweightloss.co.uk/perch/addons/apps/perch_members/edit/?id=".$memberid;
 
-     $id= perch_member_add_questionnaire_api($memberid,$data['questionnaire'],$data['type']);
+     $orderID = isset($data['order_id']) ? (int)$data['order_id'] : null;
+     if ($orderID !== null && isset($data['questionnaire']['order_id'])) {
+         unset($data['questionnaire']['order_id']);
+     }
+     $id= perch_member_add_questionnaire_api($memberid,$data['questionnaire'],$data['type'],$orderID);
       echo json_encode(["success" => true,"questionnaireID"=>$id]);
        }
   // }

--- a/perch/addons/apps/perch_members/runtime.php
+++ b/perch/addons/apps/perch_members/runtime.php
@@ -414,16 +414,16 @@ function perch_member_questionsForQuestionnaire($type) {
 
                              return true;
             }
-      function perch_member_add_questionnaire_api($memberid,$data,$type)
+      function perch_member_add_questionnaire_api($memberid,$data,$type,$orderID=null)
         {
             $API  = new PerchAPI(1.0, 'perch_members');
                            $Questionnaires = new PerchMembers_Questionnaires($API);
-                        return  $Questionnaires->add_to_member($memberid,$data,$type);
+                        return  $Questionnaires->add_to_member($memberid,$data,$type,$orderID);
 
 
                        //  return true;
         }
-    function perch_member_add_questionnaire($data,$type)
+    function perch_member_add_questionnaire($data,$type,$orderID=null)
     { //echo "perch_member_add_questionnaire";print_r($data);
       $Session = PerchMembers_Session::fetch();
 $memberid=0;
@@ -432,7 +432,7 @@ $memberid=0;
                 }
                  $API  = new PerchAPI(1.0, 'perch_members');
                    $Questionnaires = new PerchMembers_Questionnaires($API);
-                   $Questionnaires->add_to_member($memberid,$data,$type);
+                   $Questionnaires->add_to_member($memberid,$data,$type,$orderID);
 
 
                  return true;

--- a/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
@@ -217,19 +217,26 @@ class PerchShop_Order extends PerchShop_Base
         }
 
 
-        	$sql_questionnaire = 'SELECT * FROM '.PERCH_DB_PREFIX.'questionnaire
-                                                WHERE `type`="'.$questionnaire_type.'" and member_id='.$this->db->pdb((int)$Member->id());
+        	$this->ensure_questionnaire_order_column();
+
+	$sql_questionnaire = 'SELECT * FROM '.PERCH_DB_PREFIX.'questionnaire
+                                                WHERE `type`="'.$questionnaire_type.'" and member_id='.$this->db->pdb((int)$Member->id()).' AND order_id='.$this->db->pdb((int)$this->id());
                                                  // echo "products_match_pharmacy";
-                     //	print_r($sql_questionnaire);
+                     // print_r($sql_questionnaire);
                      $questionnaire = $this->db->get_rows($sql_questionnaire);
                     // print_r($questionnaire);
+                       if (!PerchUtil::count($questionnaire)) {
+                        $sql_questionnaire = 'SELECT * FROM '.PERCH_DB_PREFIX.'questionnaire
+                                                WHERE `type`="'.$questionnaire_type.'" and member_id='.$this->db->pdb((int)$Member->id());
+                        $questionnaire = $this->db->get_rows($sql_questionnaire);
+                    }
                        if (PerchUtil::count($questionnaire)) {
-                       	foreach($questionnaire as $questiondet) {
-                       	if(isset( $questiondet["question_text"]) && isset($questiondet["answer_text"])){
-                       	if($questiondet["question_text"]!="" && $questiondet["answer_text"]!="" ){
+                        foreach($questionnaire as $questiondet) {
+                        if(isset( $questiondet["question_text"]) && isset($questiondet["answer_text"])) {
+                        if($questiondet["question_text"]!="" && $questiondet["answer_text"]!="" ){
 
 
-                       		$questions_items[]  =  [
+		                       		$questions_items[]  =  [
                                                                                  "question" =>  $questiondet["question_text"],
                                                                                  "answer" =>  $questiondet["answer_text"],
                                                                              ];
@@ -293,7 +300,33 @@ class PerchShop_Order extends PerchShop_Base
          	$pharmacy_api->addOrderPharmacytodb($pharmacy_data);
 
 return $response;
-	}
+        }
+
+        protected static $questionnaire_order_column_checked = false;
+
+        protected function ensure_questionnaire_order_column()
+        {
+            if (self::$questionnaire_order_column_checked) {
+                return;
+            }
+
+            self::$questionnaire_order_column_checked = true;
+
+            $table = PERCH_DB_PREFIX.'questionnaire';
+            $columns = $this->db->get_rows('SHOW COLUMNS FROM '.$table);
+
+            if (!is_array($columns)) {
+                return;
+            }
+
+            foreach ($columns as $column) {
+                if (isset($column['Field']) && $column['Field'] === 'order_id') {
+                    return;
+                }
+            }
+
+            $this->db->execute('ALTER TABLE '.$table.' ADD COLUMN order_id int(10) unsigned DEFAULT NULL AFTER member_id');
+        }
 
 
 	public function finalize_as_paid($status='paid')

--- a/perch/templates/pages/payment/stripe/index.php
+++ b/perch/templates/pages/payment/stripe/index.php
@@ -32,9 +32,20 @@ if (empty($_SESSION['questionnaire-reorder']) && isset($_COOKIE['questionnaire_r
         }
 
         if ($redirect_to_success) {
+        $orderIdForQuestionnaire = perch_shop_successful_order_id();
+        if (!$orderIdForQuestionnaire) {
+            $ShopRuntime = PerchShop_Runtime::fetch();
+            if ($ShopRuntime) {
+                $ActiveOrder = $ShopRuntime->get_active_order();
+                if ($ActiveOrder) {
+                    $orderIdForQuestionnaire = $ActiveOrder->id();
+                }
+            }
+        }
+
         if(isset($_SESSION['questionnaire-reorder']) && !empty($_SESSION['questionnaire-reorder'])){
         unset($_SESSION['questionnaire-reorder']['nextstep']);
-    perch_member_add_questionnaire($_SESSION['questionnaire-reorder'],'re-order');
+    perch_member_add_questionnaire($_SESSION['questionnaire-reorder'],'re-order',$orderIdForQuestionnaire);
     $_SESSION['questionnaire-reorder'] = array();
     setcookie('questionnaire_reorder', '', time()-3600, '/');
     }
@@ -87,7 +98,7 @@ if (empty($_SESSION['questionnaire-reorder']) && isset($_COOKIE['questionnaire_r
             }
             $_SESSION['questionnaire']["documents"]="https://".$_SERVER['HTTP_HOST']."/perch/addons/apps/perch_members/edit/?id=".perch_member_get('id');
             //print_r( $_SESSION['questionnaire']);
-             perch_member_add_questionnaire($_SESSION['questionnaire'],'first-order');
+             perch_member_add_questionnaire($_SESSION['questionnaire'],'first-order',$orderIdForQuestionnaire);
 
              if (file_put_contents("{$logDir}/{$userId}_grouped_log.json", json_encode([
                     'metadata' => $metadata,


### PR DESCRIPTION
## Summary
- ensure the questionnaire table exposes an `order_id` column and persist the related order when saving answers
- pass order identifiers from checkout flows and the questionnaire API into the member questionnaire helper
- limit the payload sent to the pharmacy to responses recorded for the current order while retaining a legacy fallback

## Testing
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
- php -l perch/addons/apps/perch_members/runtime.php
- php -l perch/addons/apps/api/routes/add_member_questions.php
- php -l perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
- php -l perch/templates/pages/payment/stripe/index.php


------
https://chatgpt.com/codex/tasks/task_b_68cfb46838b08324b6b52436f60221ed