### PR TITLE
Normalize questionnaire dependency routing comparisons

### DIFF
--- a/perch/templates/forms/questionnaire.html
+++ b/perch/templates/forms/questionnaire.html
@@ -1551,6 +1551,48 @@
                 return (value || '').toString().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
             }
 
+            function normalizeValues(values) {
+                var list = Array.isArray(values) ? values : [values];
+                var normalized = [];
+
+                for (var i = 0; i < list.length; i++) {
+                    var item = list[i];
+                    if (item === null || typeof item === 'undefined') {
+                        continue;
+                    }
+
+                    if (Array.isArray(item)) {
+                        normalized = normalized.concat(normalizeValues(item));
+                        continue;
+                    }
+
+                    var str = String(item);
+                    var trimmed = str.trim();
+
+                    if (trimmed === '') {
+                        normalized.push('');
+                    } else {
+                        normalized.push(trimmed.toLowerCase());
+                    }
+                }
+
+                return normalized;
+            }
+
+            function hasIntersection(valuesA, valuesB) {
+                if (!valuesA.length || !valuesB.length) {
+                    return false;
+                }
+
+                for (var i = 0; i < valuesA.length; i++) {
+                    if (valuesB.indexOf(valuesA[i]) !== -1) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
             var structure = parseJSON(structureScript) || {};
             var dependencyScript = form.querySelector('.js-questionnaire-dependencies');
             var dependencies = dependencyScript ? parseJSON(dependencyScript) || {} : {};
@@ -1825,30 +1867,46 @@
 
             function dependencyRouting(question, value) {
                 var key = question.key || question.name;
+                if (!key) {
+                    return null;
+                }
+
                 var questionDependencies = dependencies[key];
-                if (!questionDependencies) {
+                if (!questionDependencies || !questionDependencies.length) {
                     return null;
                 }
 
                 var values = Array.isArray(value) ? value : [value];
+                var normalizedValues = normalizeValues(values);
 
                 for (var i = 0; i < questionDependencies.length; i++) {
                     var dependency = questionDependencies[i];
-                    if (!dependency || !dependency.step) {
+                    if (!dependency) {
                         continue;
-                    }
-                    var dependencyValues = dependency.values;
-                    if (typeof dependencyValues === 'undefined') {
-                        continue;
-                    }
-                    if (!Array.isArray(dependencyValues)) {
-                        dependencyValues = [dependencyValues];
                     }
 
-                    for (var j = 0; j < values.length; j++) {
-                        if (dependencyValues.indexOf(values[j]) !== -1) {
-                            return dependency.step;
+                    var dependencyValues = typeof dependency.values === 'undefined' ? null : dependency.values;
+                    if (dependencyValues === null) {
+                        continue;
+                    }
+
+                    var targetStep = dependency.step;
+                    if (!targetStep && dependency.question) {
+                        var dependencyQuestion = structure[dependency.question];
+                        if (dependencyQuestion && dependencyQuestion.step) {
+                            targetStep = dependencyQuestion.step;
+                        } else {
+                            targetStep = dependency.question;
                         }
+                    }
+
+                    if (!targetStep) {
+                        continue;
+                    }
+
+                    var normalizedDependencyValues = normalizeValues(dependencyValues);
+                    if (hasIntersection(normalizedValues, normalizedDependencyValues)) {
+                        return targetStep;
                     }
                 }
 

--- a/perch/templates/forms/reorder-questionnaire.html
+++ b/perch/templates/forms/reorder-questionnaire.html
@@ -384,6 +384,48 @@
                 return (value || '').toString().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
             }
 
+            function normalizeValues(values) {
+                var list = Array.isArray(values) ? values : [values];
+                var normalized = [];
+
+                for (var i = 0; i < list.length; i++) {
+                    var item = list[i];
+                    if (item === null || typeof item === 'undefined') {
+                        continue;
+                    }
+
+                    if (Array.isArray(item)) {
+                        normalized = normalized.concat(normalizeValues(item));
+                        continue;
+                    }
+
+                    var str = String(item);
+                    var trimmed = str.trim();
+
+                    if (trimmed === '') {
+                        normalized.push('');
+                    } else {
+                        normalized.push(trimmed.toLowerCase());
+                    }
+                }
+
+                return normalized;
+            }
+
+            function hasIntersection(valuesA, valuesB) {
+                if (!valuesA.length || !valuesB.length) {
+                    return false;
+                }
+
+                for (var i = 0; i < valuesA.length; i++) {
+                    if (valuesB.indexOf(valuesA[i]) !== -1) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
             var structure = parseJSON(structureScript) || {};
             var dependencyScript = form.querySelector('.js-questionnaire-dependencies');
             var dependencies = dependencyScript ? parseJSON(dependencyScript) || {} : {};
@@ -658,30 +700,46 @@
 
             function dependencyRouting(question, value) {
                 var key = question.key || question.name;
+                if (!key) {
+                    return null;
+                }
+
                 var questionDependencies = dependencies[key];
-                if (!questionDependencies) {
+                if (!questionDependencies || !questionDependencies.length) {
                     return null;
                 }
 
                 var values = Array.isArray(value) ? value : [value];
+                var normalizedValues = normalizeValues(values);
 
                 for (var i = 0; i < questionDependencies.length; i++) {
                     var dependency = questionDependencies[i];
-                    if (!dependency || !dependency.step) {
+                    if (!dependency) {
                         continue;
-                    }
-                    var dependencyValues = dependency.values;
-                    if (typeof dependencyValues === 'undefined') {
-                        continue;
-                    }
-                    if (!Array.isArray(dependencyValues)) {
-                        dependencyValues = [dependencyValues];
                     }
 
-                    for (var j = 0; j < values.length; j++) {
-                        if (dependencyValues.indexOf(values[j]) !== -1) {
-                            return dependency.step;
+                    var dependencyValues = typeof dependency.values === 'undefined' ? null : dependency.values;
+                    if (dependencyValues === null) {
+                        continue;
+                    }
+
+                    var targetStep = dependency.step;
+                    if (!targetStep && dependency.question) {
+                        var dependencyQuestion = structure[dependency.question];
+                        if (dependencyQuestion && dependencyQuestion.step) {
+                            targetStep = dependencyQuestion.step;
+                        } else {
+                            targetStep = dependency.question;
                         }
+                    }
+
+                    if (!targetStep) {
+                        continue;
+                    }
+
+                    var normalizedDependencyValues = normalizeValues(dependencyValues);
+                    if (hasIntersection(normalizedValues, normalizedDependencyValues)) {
+                        return targetStep;
                     }
                 }
 

--- a/perch/templates/pages/client/reorder-questionnaire.php
+++ b/perch/templates/pages/client/reorder-questionnaire.php
@@ -16,9 +16,11 @@ if (empty($_SESSION['questionnaire-reorder']) && isset($_COOKIE['questionnaire_r
          mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
      );
  }
+    $requested_step = isset($_GET['step']) ? trim((string)$_GET['step']) : null;
+
     if (isset($_POST['nextstep'])) {
     $user_id = generateUUID();
-    $current_step = $_GET["step"];
+    $current_step = $requested_step ?? '';
     $timestamp = time();
        // Secret key (keep this safe, use env file ideally)
                         $secret_key = 'theoloss1066';
@@ -127,13 +129,14 @@ if (empty($_SESSION['questionnaire-reorder']) && isset($_COOKIE['questionnaire_r
         <div class="main_product">
             <div id="product-selection">
                <h2 class="text-center fw-bolder">Before we send you your next dose we have a few questions! </h2>
-    <?php
-if(isset( $_GET["step"])){
-
-PerchSystem::set_var('step', $_GET["step"]);
-}
-
+<?php
 $reorder_structure = perch_member_questionnaire_structure('re-order');
+$grouped_steps = [];
+$step_sort_index = [];
+$dependency_steps = [];
+$ordered_step_keys = [];
+$first_step = 'weight';
+
 if (is_array($reorder_structure) && PerchUtil::count($reorder_structure)) {
     PerchSystem::set_var('questionnaire_structure_json', PerchUtil::json_safe_encode($reorder_structure));
 
@@ -142,8 +145,6 @@ if (is_array($reorder_structure) && PerchUtil::count($reorder_structure)) {
         PerchSystem::set_var('questionnaire_dependencies_json', PerchUtil::json_safe_encode($reorder_dependencies));
     }
 
-    $grouped_steps = [];
-    $step_sort_index = [];
     foreach ($reorder_structure as $question) {
         $step = isset($question['step']) && $question['step'] !== '' ? $question['step'] : $question['key'];
         $question_sort = isset($question['sort']) ? (int)$question['sort'] : PHP_INT_MAX;
@@ -158,6 +159,28 @@ if (is_array($reorder_structure) && PerchUtil::count($reorder_structure)) {
         }
 
         $grouped_steps[$step][] = $question['key'];
+
+        if (isset($question['dependencies']) && is_array($question['dependencies'])) {
+            foreach ($question['dependencies'] as $dependency) {
+                if (!is_array($dependency)) {
+                    continue;
+                }
+
+                if (!empty($dependency['step'])) {
+                    $dependency_steps[] = $dependency['step'];
+                    continue;
+                }
+
+                if (!empty($dependency['question'])) {
+                    $target_question = $dependency['question'];
+                    if (isset($reorder_structure[$target_question]['step']) && $reorder_structure[$target_question]['step'] !== '') {
+                        $dependency_steps[] = $reorder_structure[$target_question]['step'];
+                    } else {
+                        $dependency_steps[] = $target_question;
+                    }
+                }
+            }
+        }
     }
 
     foreach ($grouped_steps as $step => &$keys) {
@@ -188,16 +211,26 @@ if (is_array($reorder_structure) && PerchUtil::count($reorder_structure)) {
         }
 
         PerchSystem::set_var('questionnaire_steps_json', PerchUtil::json_safe_encode($grouped_steps));
-        reset($grouped_steps);
-        $first_step = key($grouped_steps);
-        if (!$first_step) {
-            $first_step = 'weight';
+        $ordered_step_keys = array_keys($grouped_steps);
+        if (count($ordered_step_keys)) {
+            $first_step = $ordered_step_keys[0];
         }
-        $current_step = $_GET['step'] ?? $first_step;
-        PerchSystem::set_var('questionnaire_default_step', $first_step);
-        PerchSystem::set_var('questionnaire_current_step', $current_step);
     }
 }
+
+$allowed_steps = array_values(array_unique(array_merge($ordered_step_keys, $dependency_steps)));
+if (!in_array($first_step, $allowed_steps, true)) {
+    $allowed_steps[] = $first_step;
+}
+
+$current_step = $requested_step ?: $first_step;
+if (!in_array($current_step, $allowed_steps, true)) {
+    $current_step = $first_step;
+}
+
+PerchSystem::set_var('step', $current_step);
+PerchSystem::set_var('questionnaire_default_step', $first_step);
+PerchSystem::set_var('questionnaire_current_step', $current_step);
 
 $reorder_answers = $_SESSION['questionnaire-reorder'] ?? [];
 if (PerchUtil::count($reorder_answers)) {

--- a/perch/templates/pages/getStarted/questionnaire.php
+++ b/perch/templates/pages/getStarted/questionnaire.php
@@ -169,11 +169,13 @@ if ($lastPart === 'consultation') {
     $_SESSION['questionnaire']['consultation'] = 'agree';
 }
 
+$requested_step = isset($_GET['step']) ? trim((string)$_GET['step']) : null;
+
 if (isset($_POST['nextstep'])) {
     $_SESSION['questionnaire']['confirmed'] = false;
 
     $user_id = generateUUID();
-    $current_step = $_GET['step'] ?? '';
+    $current_step = $requested_step ?? '';
     $timestamp = time();
 
     $secret_key = 'theoloss1066';
@@ -285,7 +287,7 @@ setcookie('questionnaire', json_encode($_SESSION['questionnaire'] ?? []), time()
 
     ?>
 
-<?php PerchSystem::set_var('step', $_GET["step"]);
+<?php
 PerchSystem::set_var('reviewed', $_SESSION['questionnaire']['reviewed']);
 $back_links = [
     'howold' => '/get-started',
@@ -351,13 +353,17 @@ $back_links['conditions']="/get-started/questionnaire?step=more_pancreatitis";
         $back_links['medications']="/get-started/questionnaire?step=medical_conditions";
        }
 
-           if(isset($_SESSION['questionnaire']['effects_with_wegovy']) && $_SESSION['questionnaire']['effects_with_wegovy']=="no"){
+           if(isset($_SESSION['questionnaire']['effects_with_wegovy']) && $_SESSION['questionnaire']['effects_with_wegovy']=="no"){ 
                     $back_links['medication_allergies']="/get-started/questionnaire?step=effects_with_wegovy";
           }
 
-$back_link = $back_links[$_GET["step"]] ?? '/get-started';
-
 $questionnaire_structure = perch_member_questionnaire_structure('first-order');
+$grouped_steps = [];
+$step_sort_index = [];
+$dependency_steps = [];
+$ordered_step_keys = [];
+$first_step = 'howold';
+
 if (is_array($questionnaire_structure) && PerchUtil::count($questionnaire_structure)) {
     PerchSystem::set_var('questionnaire_structure_json', PerchUtil::json_safe_encode($questionnaire_structure));
 
@@ -366,8 +372,6 @@ if (is_array($questionnaire_structure) && PerchUtil::count($questionnaire_struct
         PerchSystem::set_var('questionnaire_dependencies_json', PerchUtil::json_safe_encode($questionnaire_dependencies));
     }
 
-    $grouped_steps = [];
-    $step_sort_index = [];
     foreach ($questionnaire_structure as $question) {
         $step = isset($question['step']) && $question['step'] !== '' ? $question['step'] : $question['key'];
         $question_sort = isset($question['sort']) ? (int)$question['sort'] : PHP_INT_MAX;
@@ -382,6 +386,28 @@ if (is_array($questionnaire_structure) && PerchUtil::count($questionnaire_struct
         }
 
         $grouped_steps[$step][] = $question['key'];
+
+        if (isset($question['dependencies']) && is_array($question['dependencies'])) {
+            foreach ($question['dependencies'] as $dependency) {
+                if (!is_array($dependency)) {
+                    continue;
+                }
+
+                if (!empty($dependency['step'])) {
+                    $dependency_steps[] = $dependency['step'];
+                    continue;
+                }
+
+                if (!empty($dependency['question'])) {
+                    $target_question = $dependency['question'];
+                    if (isset($questionnaire_structure[$target_question]['step']) && $questionnaire_structure[$target_question]['step'] !== '') {
+                        $dependency_steps[] = $questionnaire_structure[$target_question]['step'];
+                    } else {
+                        $dependency_steps[] = $target_question;
+                    }
+                }
+            }
+        }
     }
 
     foreach ($grouped_steps as $step => &$keys) {
@@ -412,16 +438,28 @@ if (is_array($questionnaire_structure) && PerchUtil::count($questionnaire_struct
         }
 
         PerchSystem::set_var('questionnaire_steps_json', PerchUtil::json_safe_encode($grouped_steps));
-        reset($grouped_steps);
-        $first_step = key($grouped_steps);
-        if (!$first_step) {
-            $first_step = 'howold';
+        $ordered_step_keys = array_keys($grouped_steps);
+        if (count($ordered_step_keys)) {
+            $first_step = $ordered_step_keys[0];
         }
-        $current_step = $_GET['step'] ?? $first_step;
-        PerchSystem::set_var('questionnaire_default_step', $first_step);
-        PerchSystem::set_var('questionnaire_current_step', $current_step);
     }
 }
+
+$allowed_steps = array_values(array_unique(array_merge($ordered_step_keys, $dependency_steps)));
+if (!in_array($first_step, $allowed_steps, true)) {
+    $allowed_steps[] = $first_step;
+}
+
+$current_step = $requested_step ?: $first_step;
+if (!in_array($current_step, $allowed_steps, true)) {
+    $current_step = $first_step;
+}
+
+$back_link = $back_links[$current_step] ?? '/get-started';
+
+PerchSystem::set_var('step', $current_step);
+PerchSystem::set_var('questionnaire_default_step', $first_step);
+PerchSystem::set_var('questionnaire_current_step', $current_step);
 
 $answers = $_SESSION['questionnaire'] ?? [];
 PerchSystem::set_var('previousPage', $back_link);


### PR DESCRIPTION
## Summary
- expand the dependency step collection on questionnaire pages to honour question fallbacks
- normalise questionnaire answers and dependency values before matching to respect case and whitespace differences
- fallback to dependency question targets when an explicit step is absent for both first-order and reorder flows

## Testing
- php -l perch/templates/pages/client/reorder-questionnaire.php
- php -l perch/templates/pages/getStarted/questionnaire.php

------
https://chatgpt.com/codex/tasks/task_b_68cfafe622348324b9c2aea840199f3b