### PR TITLE
Compute reorder next step from current response

### DIFF
--- a/perch/templates/forms/reorder-questionnaire.html
+++ b/perch/templates/forms/reorder-questionnaire.html
@@ -426,7 +426,163 @@
                 return false;
             }
 
+            function hasUsableValue(value) {
+                if (value === null || typeof value === 'undefined') {
+                    return false;
+                }
+
+                if (Array.isArray(value)) {
+                    return value.length > 0;
+                }
+
+                if (typeof value === 'string') {
+                    return value.trim() !== '';
+                }
+
+                return true;
+            }
+
+            function collectSelectorNames(questionKey, question) {
+                var names = [];
+                var seen = {};
+
+                function addName(name) {
+                    if (!name || seen[name]) {
+                        return;
+                    }
+                    seen[name] = true;
+                    names.push(name);
+                }
+
+                if (question && question.name) {
+                    addName(question.name);
+                    if (question.name.slice(-2) === '[]') {
+                        addName(question.name.slice(0, -2));
+                    }
+                }
+
+                if (questionKey) {
+                    addName(questionKey);
+                    if (questionKey.slice(-2) === '[]') {
+                        addName(questionKey.slice(0, -2));
+                    }
+                }
+
+                if (questionKey && Object.prototype.hasOwnProperty.call(questionAliasesByKey, questionKey)) {
+                    var aliases = questionAliasesByKey[questionKey];
+                    for (var i = 0; i < aliases.length; i++) {
+                        var alias = aliases[i];
+                        if (typeof alias !== 'string') {
+                            continue;
+                        }
+                        addName(alias);
+                        if (alias.slice(-2) === '[]') {
+                            addName(alias.slice(0, -2));
+                        }
+                    }
+                }
+
+                return names;
+            }
+
+            function storeAnswerValue(identifier, value) {
+                if (!identifier) {
+                    return;
+                }
+
+                answerState[identifier] = value;
+
+                var resolvedKey = null;
+                if (Object.prototype.hasOwnProperty.call(questionByName, identifier)) {
+                    resolvedKey = questionByName[identifier];
+                } else if (Object.prototype.hasOwnProperty.call(questionNameByKey, identifier)) {
+                    resolvedKey = identifier;
+                }
+
+                if (resolvedKey) {
+                    if (resolvedKey !== identifier) {
+                        answerState[resolvedKey] = value;
+                    }
+
+                    var canonicalName = questionNameByKey[resolvedKey];
+                    if (canonicalName && canonicalName !== identifier) {
+                        answerState[canonicalName] = value;
+                    }
+
+                    if (Object.prototype.hasOwnProperty.call(questionAliasesByKey, resolvedKey)) {
+                        var aliasList = questionAliasesByKey[resolvedKey];
+                        for (var i = 0; i < aliasList.length; i++) {
+                            var aliasName = aliasList[i];
+                            if (typeof aliasName !== 'string' || aliasName === identifier) {
+                                continue;
+                            }
+                            answerState[aliasName] = value;
+                        }
+                    }
+                }
+            }
+
+            function getStoredAnswer(questionKey, questionName) {
+                if (questionKey && Object.prototype.hasOwnProperty.call(answerState, questionKey) && hasUsableValue(answerState[questionKey])) {
+                    return answerState[questionKey];
+                }
+
+                if (questionName && Object.prototype.hasOwnProperty.call(answerState, questionName) && hasUsableValue(answerState[questionName])) {
+                    return answerState[questionName];
+                }
+
+                if (questionKey && Object.prototype.hasOwnProperty.call(questionAliasesByKey, questionKey)) {
+                    var aliases = questionAliasesByKey[questionKey];
+                    for (var i = 0; i < aliases.length; i++) {
+                        var alias = aliases[i];
+                        if (typeof alias !== 'string') {
+                            continue;
+                        }
+
+                        if (Object.prototype.hasOwnProperty.call(answerState, alias) && hasUsableValue(answerState[alias])) {
+                            return answerState[alias];
+                        }
+                    }
+                }
+
+                return null;
+            }
+
             var structure = parseJSON(structureScript) || {};
+            var questionByName = {};
+            var questionNameByKey = {};
+            var questionAliasesByKey = {};
+
+            Object.keys(structure).forEach(function (key) {
+                var question = structure[key];
+                if (!question) {
+                    return;
+                }
+
+                var canonicalName = question.name || key;
+                questionNameByKey[key] = canonicalName;
+
+                if (canonicalName && !Object.prototype.hasOwnProperty.call(questionByName, canonicalName)) {
+                    questionByName[canonicalName] = key;
+                }
+
+                if (!Object.prototype.hasOwnProperty.call(questionByName, key)) {
+                    questionByName[key] = key;
+                }
+
+                if (Array.isArray(question.aliases)) {
+                    questionAliasesByKey[key] = question.aliases.slice();
+                    question.aliases.forEach(function (alias) {
+                        if (typeof alias !== 'string') {
+                            return;
+                        }
+
+                        if (!Object.prototype.hasOwnProperty.call(questionByName, alias)) {
+                            questionByName[alias] = key;
+                        }
+                    });
+                }
+            });
             var dependencyScript = form.querySelector('.js-questionnaire-dependencies');
             var dependencies = dependencyScript ? parseJSON(dependencyScript) || {} : {};
             var stepsScript = form.querySelector('.js-questionnaire-steps');
@@ -446,45 +602,83 @@
             var answerState = {};
             if (storedAnswers && typeof storedAnswers === 'object') {
                 for (var storedKey in storedAnswers) {
-                    if (storedAnswers.hasOwnProperty(storedKey)) {
-                        answerState[storedKey] = storedAnswers[storedKey];
+                    if (Object.prototype.hasOwnProperty.call(storedAnswers, storedKey)) {
+                        storeAnswerValue(storedKey, storedAnswers[storedKey]);
                     }
                 }
             }
 
+            Object.keys(structure).forEach(function (key) {
+                var question = structure[key];
+                if (!question) {
+                    return;
+                }
+
+                var stored = getStoredAnswer(key, question.name || key);
+                if (hasUsableValue(stored)) {
+                    storeAnswerValue(key, stored);
+                }
+            });
+
             applyQuestionLabels(form, structure);
+
+            Object.keys(structure).forEach(function (key) {
+                var question = structure[key];
+                if (!question) {
+                    return;
+                }
+
+                var storedValue = getStoredAnswer(key, question.name || key);
+                if (hasUsableValue(storedValue)) {
+                    toggleActiveButtons(question.name || key, storedValue);
+                }
+            });
 
             form.addEventListener('change', function (event) {
                 var target = event.target;
                 if (!target || !target.name) {
                     return;
                 }
-                if (target.type === 'radio' || target.type === 'checkbox') {
-                    toggleActiveButtons(target.name, readValueFromInput(target));
+                var updatedValue = readValueFromInput(target);
+                if (target.type === 'radio') {
+                    var groupSelector = '[name="' + cssEscape(target.name) + '"]:checked';
+                    var activeRadio = form.querySelector(groupSelector);
+                    updatedValue = activeRadio ? activeRadio.value : null;
                 }
-                updateNextStep();
+                if (target.type === 'radio' || target.type === 'checkbox') {
+                    toggleActiveButtons(target.name, updatedValue);
+                }
+                storeAnswerValue(target.name, updatedValue);
+                updateNextStep(target.name, updatedValue);
             }, true);
 
             form.addEventListener('submit', function () {
                 updateNextStep();
             });
 
-            window.submitForm = function () {
-                updateNextStep();
+            window.submitForm = function (questionKey) {
+                var providedValue;
+                if (typeof questionKey !== 'undefined') {
+                    providedValue = readImmediateValue(questionKey);
+                    if (typeof providedValue !== 'undefined') {
+                        storeAnswerValue(questionKey, providedValue);
+                    }
+                }
+                updateNextStep(questionKey, providedValue);
                 form.submit();
             };
 
             window.setValuesForm = function (questionKey, value) {
                 setHiddenValue(questionKey, value);
                 toggleActiveButtons(questionKey, value);
-                updateNextStep();
+                updateNextStep(questionKey, value);
                 form.submit();
             };
 
             window.setValuesreorderForm = function (questionKey, value) {
                 setHiddenValue(questionKey, value);
                 toggleActiveButtons(questionKey, value);
-                updateNextStep();
+                updateNextStep(questionKey, value);
                 form.submit();
             };
 
@@ -521,6 +715,11 @@
                 var maxSort = (typeof Number !== 'undefined' && typeof Number.MAX_SAFE_INTEGER === 'number')
                     ? Number.MAX_SAFE_INTEGER
                     : Math.pow(2, 53) - 1;
+                var originalOrder = {};
+
+                for (var index = 0; index < steps.length; index++) {
+                    originalOrder[steps[index]] = index;
+                }
 
                 function minSortForStep(stepKey) {
                     var questions = stepQuestions[stepKey] || [];
@@ -539,11 +738,17 @@
                     return min;
                 }
 
-                return steps.sort(function (a, b) {
+                var sortedSteps = steps.slice();
+                return sortedSteps.sort(function (a, b) {
                     var sortA = minSortForStep(a);
                     var sortB = minSortForStep(b);
                     if (sortA === sortB) {
-                        return a.localeCompare(b);
+                        var originalA = Object.prototype.hasOwnProperty.call(originalOrder, a) ? originalOrder[a] : 0;
+                        var originalB = Object.prototype.hasOwnProperty.call(originalOrder, b) ? originalOrder[b] : 0;
+                        if (originalA === originalB) {
+                            return String(a).localeCompare(String(b));
+                        }
+                        return originalA - originalB;
                     }
                     return sortA - sortB;
                 });
@@ -655,18 +860,206 @@
                 });
             }
 
-            function updateNextStep() {
+            function resolveQuestionKey(identifier) {
+                if (!identifier) {
+                    return null;
+                }
+
+                if (Object.prototype.hasOwnProperty.call(structure, identifier)) {
+                    return identifier;
+                }
+
+                if (Object.prototype.hasOwnProperty.call(questionByName, identifier)) {
+                    return questionByName[identifier];
+                }
+
+                if (identifier.slice(-2) === '[]') {
+                    var trimmed = identifier.slice(0, -2);
+                    if (Object.prototype.hasOwnProperty.call(structure, trimmed)) {
+                        return trimmed;
+                    }
+                    if (Object.prototype.hasOwnProperty.call(questionByName, trimmed)) {
+                        return questionByName[trimmed];
+                    }
+                }
+
+                if (identifier.indexOf('-') !== -1) {
+                    var normalized = identifier.replace(/-/g, '_');
+                    if (Object.prototype.hasOwnProperty.call(structure, normalized)) {
+                        return normalized;
+                    }
+                    if (Object.prototype.hasOwnProperty.call(questionByName, normalized)) {
+                        return questionByName[normalized];
+                    }
+                }
+
+                return null;
+            }
+
+            function getStepForQuestionKey(questionKey) {
+                if (!questionKey || !Object.prototype.hasOwnProperty.call(structure, questionKey)) {
+                    return null;
+                }
+
+                var question = structure[questionKey];
+                if (!question) {
+                    return null;
+                }
+
+                if (question.step && question.step !== '') {
+                    return question.step;
+                }
+
+                return questionKey;
+            }
+
+            function computeNextStepFromContext(identifier, providedValue) {
+                if (!identifier) {
+                    return null;
+                }
+
+                var resolvedKey = resolveQuestionKey(identifier);
+                if (!resolvedKey) {
+                    return null;
+                }
+
+                var question = structure[resolvedKey];
+                if (!question) {
+                    return null;
+                }
+
+                var value = (typeof providedValue === 'undefined') ? readAnswer(question, resolvedKey) : providedValue;
+                if (!hasUsableValue(value)) {
+                    return null;
+                }
+
+                var dependencyNext = dependencyRouting(question, value);
+                if (dependencyNext) {
+                    return dependencyNext;
+                }
+
+                var questionStep = getStepForQuestionKey(resolvedKey);
+                if (!questionStep) {
+                    return null;
+                }
+
+                var index = stepOrder.indexOf(questionStep);
+                if (index !== -1 && index + 1 < stepOrder.length) {
+                    return stepOrder[index + 1];
+                }
+
+                return finalStep;
+            }
+
+            function readImmediateValue(identifier) {
+                if (!identifier) {
+                    return undefined;
+                }
+
+                var resolvedKey = resolveQuestionKey(identifier) || identifier;
+                var question = Object.prototype.hasOwnProperty.call(structure, resolvedKey) ? structure[resolvedKey] : null;
+                var selectorNames = collectSelectorNames(resolvedKey, question);
+
+                if (!selectorNames.length) {
+                    selectorNames = [];
+                    if (resolvedKey) {
+                        selectorNames.push(resolvedKey);
+                    }
+                    if (identifier && selectorNames.indexOf(identifier) === -1) {
+                        selectorNames.push(identifier);
+                    }
+                }
+
+                for (var i = 0; i < selectorNames.length; i++) {
+                    var field = form.querySelector('[name="' + cssEscape(selectorNames[i]) + '"]');
+                    if (!field) {
+                        continue;
+                    }
+
+                    if (field.type === 'checkbox') {
+                        return readValueFromInput(field);
+                    }
+
+                    if (field.type === 'radio') {
+                        var checkedRadio = form.querySelector('[name="' + cssEscape(selectorNames[i]) + '"]:checked');
+                        return checkedRadio ? checkedRadio.value : null;
+                    }
+
+                    return field.value;
+                }
+
+                var idCandidates = [];
+
+                if (identifier && idCandidates.indexOf(identifier) === -1) {
+                    idCandidates.push(identifier);
+                }
+
+                if (resolvedKey && idCandidates.indexOf(resolvedKey) === -1) {
+                    idCandidates.push(resolvedKey);
+                }
+
+                for (var j = 0; j < selectorNames.length; j++) {
+                    if (idCandidates.indexOf(selectorNames[j]) === -1) {
+                        idCandidates.push(selectorNames[j]);
+                    }
+                }
+
+                if (resolvedKey && Object.prototype.hasOwnProperty.call(questionAliasesByKey, resolvedKey)) {
+                    var aliasList = questionAliasesByKey[resolvedKey];
+                    for (var k = 0; k < aliasList.length; k++) {
+                        var aliasName = aliasList[k];
+                        if (typeof aliasName !== 'string') {
+                            continue;
+                        }
+                        if (idCandidates.indexOf(aliasName) === -1) {
+                            idCandidates.push(aliasName);
+                        }
+                    }
+                }
+
+                for (var index = 0; index < idCandidates.length; index++) {
+                    var element = document.getElementById(idCandidates[index]);
+                    if (!element) {
+                        continue;
+                    }
+
+                    if (element.type === 'checkbox') {
+                        return readValueFromInput(element);
+                    }
+
+                    if (element.type === 'radio') {
+                        if (element.name) {
+                            var checkedByName = form.querySelector('[name="' + cssEscape(element.name) + '"]:checked');
+                            if (checkedByName) {
+                                return checkedByName.value;
+                            }
+                        }
+                        return element.checked ? element.value : null;
+                    }
+
+                    return element.value;
+                }
+
+                return undefined;
+            }
+
+            function updateNextStep(changedIdentifier, providedValue) {
                 var fields = form.querySelectorAll('input[name="nextstep"]');
                 if (!fields.length) {
                     return;
                 }
-                var next = computeNextStep();
+                var next = computeNextStep(changedIdentifier, providedValue);
                 Array.prototype.forEach.call(fields, function (field) {
                     field.value = next || '';
                 });
             }
 
-            function computeNextStep() {
+            function computeNextStep(changedIdentifier, providedValue) {
+                var contextual = computeNextStepFromContext(changedIdentifier, providedValue);
+                if (contextual) {
+                    return contextual;
+                }
+
                 var step = currentStep || stepOrder[0] || '';
                 if (!step) {
                     return '';
@@ -679,7 +1072,7 @@
                     if (!question) {
                         continue;
                     }
-                    var value = readAnswer(question);
+                    var value = readAnswer(question, key);
                     if (value === null || typeof value === 'undefined' || (Array.isArray(value) && !value.length)) {
                         continue;
                     }
@@ -746,36 +1139,98 @@
                 return null;
             }
 
-            function readAnswer(question) {
-                var name = question.name || question.key;
-                if (!name) {
+            function readAnswer(question, questionKey) {
+                var key = questionKey || (question && question.key) || null;
+                var name = question && question.name ? question.name : key;
+                var storedValue = getStoredAnswer(key, name);
+
+                if (hasUsableValue(storedValue)) {
+                    return storedValue;
+                }
+
+                var selectorNames = collectSelectorNames(key, question);
+
+                if (question && question.type === 'checkbox') {
+                    for (var i = 0; i < selectorNames.length; i++) {
+                        var checkboxName = selectorNames[i];
+                        var nodes = form.querySelectorAll('[name="' + cssEscape(checkboxName) + '"]');
+                        if (!nodes.length) {
+                            continue;
+                        }
+                        var values = [];
+                        Array.prototype.forEach.call(nodes, function (node) {
+                            if (node.checked) {
+                                values.push(node.value);
+                            }
+                        });
+                        if (values.length) {
+                            storeAnswerValue(checkboxName, values);
+                            return values;
+                        }
+                    }
+                    return [];
+                }
+
+                if (question && question.type === 'radio') {
+                    for (var j = 0; j < selectorNames.length; j++) {
+                        var radioName = selectorNames[j];
+                        var checked = form.querySelector('[name="' + cssEscape(radioName) + '"]:checked');
+                        if (checked && hasUsableValue(checked.value)) {
+                            storeAnswerValue(radioName, checked.value);
+                            return checked.value;
+                        }
+                    }
                     return null;
                 }
 
-                var selector = '[name="' + cssEscape(name) + '"]';
-                if (question.type === 'checkbox') {
-                    var values = [];
-                    var nodes = form.querySelectorAll(selector);
-                    Array.prototype.forEach.call(nodes, function (node) {
-                        if (node.checked) {
-                            values.push(node.value);
+                for (var k = 0; k < selectorNames.length; k++) {
+                    var input = form.querySelector('[name="' + cssEscape(selectorNames[k]) + '"]');
+                    if (input) {
+                        var inputValue = input.value;
+                        if (hasUsableValue(inputValue)) {
+                            storeAnswerValue(selectorNames[k], inputValue);
+                            return inputValue;
                         }
-                    });
-                    answerState[name] = values;
-                    return values;
+                    }
                 }
 
-                if (question.type === 'radio') {
-                    var checked = form.querySelector(selector + ':checked');
-                    var radioValue = checked ? checked.value : null;
-                    answerState[name] = radioValue;
-                    return radioValue;
+                var idCandidates = [];
+                if (key) {
+                    idCandidates.push(key);
+                }
+                if (name && idCandidates.indexOf(name) === -1) {
+                    idCandidates.push(name);
                 }
 
-                var input = form.querySelector(selector);
-                var inputValue = input ? input.value : null;
-                answerState[name] = inputValue;
-                return inputValue;
+                for (var index = 0; index < idCandidates.length; index++) {
+                    var element = document.getElementById(idCandidates[index]);
+                    if (!element) {
+                        continue;
+                    }
+
+                    if (question && question.type === 'checkbox') {
+                        if (element.checked) {
+                            storeAnswerValue(idCandidates[index], [element.value]);
+                            return [element.value];
+                        }
+                        continue;
+                    }
+
+                    if (question && question.type === 'radio') {
+                        if (element.checked && hasUsableValue(element.value)) {
+                            storeAnswerValue(idCandidates[index], element.value);
+                            return element.value;
+                        }
+                        continue;
+                    }
+
+                    if (hasUsableValue(element.value)) {
+                        storeAnswerValue(idCandidates[index], element.value);
+                        return element.value;
+                    }
+                }
+
+                return null;
             }
 
             function setHiddenValue(questionKey, value) {
@@ -786,13 +1241,26 @@
                 if (!field) {
                     field = form.querySelector('[name="' + cssEscape(questionKey) + '[]"]');
                 }
+                if (!field && Object.prototype.hasOwnProperty.call(questionByName, questionKey)) {
+                    var resolvedKey = questionByName[questionKey];
+                    if (resolvedKey && resolvedKey !== questionKey) {
+                        field = document.getElementById(resolvedKey);
+                        if (!field) {
+                            field = form.querySelector('[name="' + cssEscape(resolvedKey) + '"]');
+                        }
+                        if (!field) {
+                            field = form.querySelector('[name="' + cssEscape(resolvedKey) + '[]"]');
+                        }
+                    }
+                }
                 if (!field) {
                     return;
                 }
 
                 if (field.type === 'checkbox') {
                     var values = Array.isArray(value) ? value : [value];
-                    var nodes = form.querySelectorAll('[name="' + cssEscape(field.name) + '"]');
+                    var checkboxName = field.name || questionKey;
+                    var nodes = form.querySelectorAll('[name="' + cssEscape(checkboxName) + '"]');
                     Array.prototype.forEach.call(nodes, function (node) {
                         node.checked = values.indexOf(node.value) !== -1;
                     });
@@ -800,7 +1268,10 @@
                     field.value = value;
                 }
 
-                answerState[questionKey] = value;
+                storeAnswerValue(questionKey, value);
+                if (field.name && field.name !== questionKey) {
+                    storeAnswerValue(field.name, value);
+                }
             }
 
             function toggleActiveButtons(questionKey, value) {


### PR DESCRIPTION
## Summary
- propagate the identifier and latest value through change handlers and submit helpers so next-step updates use the response that was just provided
- add helpers to resolve canonical question keys, read the current DOM value, and compute contextual dependency targets before defaulting to step order
- update the next-step resolver to prioritise dependency routing from the freshly supplied answer while retaining the existing fallbacks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d114c095e483248999555aa9ccd1d1