### PR TITLE
Use Perch DB escaping when building questionnaire insert query

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
@@ -1119,11 +1119,17 @@ if(isset($data["uuid"])){
            $columns = implode(", ", array_keys($qdata)); // Columns as a string
                       //  $values = "'" . implode("', '", array_map('addslashes', array_values($qdata))) . "'";
 
-          $escaped_values = array_map(function($value) {
-              return mysqli_real_escape_string($this->db->get_link(), $value);
-          }, array_values($qdata));
+           $db = $this->db;
 
-          $values = "'" . implode("', '", $escaped_values) . "'";
+           $escaped_values = array_map(function ($value) use ($db) {
+               if (is_string($value)) {
+                   $value = PerchUtil::safe_stripslashes($value);
+               }
+
+               return $db->pdb($value);
+           }, array_values($qdata));
+
+           $values = implode(', ', $escaped_values);
 
            $insert_query .="INSERT INTO ".PERCH_DB_PREFIX."questionnaire (".$columns.") VALUES (".$values."); ";
 


### PR DESCRIPTION
## Summary
- replace direct usage of `mysqli_real_escape_string()` with the built-in Perch database escape helper when inserting questionnaire records
- build the values clause from the escaped outputs to maintain proper quoting across value types
- normalize string answers with `PerchUtil::safe_stripslashes()` before quoting so embedded apostrophes remain valid

## Testing
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php

------
https://chatgpt.com/codex/tasks/task_b_68d2a1928d2c832496cc531835bda9cb