### PR TITLE
Refactor weight measurement API to use repository

### DIFF
--- a/perch/addons/apps/api/index.php
+++ b/perch/addons/apps/api/index.php
@@ -1,16 +1,53 @@
 <?php
 header("Content-Type: application/json");
 
-$requestMethod = $_SERVER['REQUEST_METHOD'];
-$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-$path = str_replace("/api", "", $path);
-//echo "path".$path ;
-$routeFile = __DIR__ . "/routes{$path}.php";
-//echo $routeFile ;
-if (file_exists($routeFile)) {
-
-    require $routeFile;
-} else {
-  //  http_response_code(404);
-    echo json_encode(["error" => "Endpoint not found"]);
+$rawPath = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$relativePath = preg_replace('#^/api#', '', $rawPath ?? '');
+$relativePath = '/' . ltrim((string)$relativePath, '/');
+$relativePath = preg_replace('#/+#', '/', $relativePath);
+$relativePath = rtrim($relativePath, '/');
+if ($relativePath === '') {
+    $relativePath = '/';
 }
+
+$segments = $relativePath === '/' ? [] : explode('/', ltrim($relativePath, '/'));
+$routeFile = null;
+$routeParams = [];
+$routesDir = __DIR__ . '/routes';
+
+for ($i = count($segments); $i >= 0; $i--) {
+    $currentSegments = array_slice($segments, 0, $i);
+    $currentPath = $i ? '/' . implode('/', $currentSegments) : '';
+    $fileCandidate = $currentPath === ''
+        ? $routesDir . '/index.php'
+        : $routesDir . $currentPath . '.php';
+    $directoryCandidate = $currentPath === ''
+        ? $fileCandidate
+        : $routesDir . $currentPath . '/index.php';
+
+    if (file_exists($fileCandidate)) {
+        $routeFile = $fileCandidate;
+        $routeParams = array_slice($segments, $i);
+        break;
+    }
+
+    if (file_exists($directoryCandidate)) {
+        $routeFile = $directoryCandidate;
+        $routeParams = array_slice($segments, $i);
+        break;
+    }
+}
+
+if ($routeFile) {
+    global $_ROUTE;
+    $_ROUTE = [
+        'path' => $relativePath,
+        'segments' => $segments,
+        'params' => $routeParams,
+    ];
+    require $routeFile;
+    return;
+}
+
+http_response_code(404);
+echo json_encode(["error" => "Endpoint not found"]);

--- a/perch/addons/apps/api/routes/weight-measurements/WeightMeasurementsRepository.php
+++ b/perch/addons/apps/api/routes/weight-measurements/WeightMeasurementsRepository.php
@@ -1,0 +1,200 @@
+<?php
+
+class WeightMeasurementsRepository
+{
+    private $db;
+    private $table;
+
+    public function __construct($db = null)
+    {
+        $this->db = $db ?: PerchDB::fetch();
+        $this->table = wl_weight_measurements_table();
+    }
+
+    public function countForMember($memberId, $startDate = null, $endDate = null)
+    {
+        $sql = 'SELECT COUNT(*) FROM ' . $this->table . ' WHERE ' . $this->buildDateRangeWhere($memberId, $startDate, $endDate);
+
+        $total = $this->db->get_count($sql);
+
+        if (!is_int($total)) {
+            return 0;
+        }
+
+        return $total;
+    }
+
+    public function fetchPageForMember($memberId, $limit, $offset, $startDate = null, $endDate = null)
+    {
+        $where = $this->buildDateRangeWhere($memberId, $startDate, $endDate);
+
+        $sql = 'SELECT * FROM ' . $this->table
+            . ' WHERE ' . $where
+            . ' ORDER BY measurement_date DESC'
+            . ' LIMIT ' . (int)$offset . ', ' . (int)$limit;
+
+        $rows = $this->db->get_rows($sql);
+
+        return is_array($rows) ? $rows : [];
+    }
+
+    public function fetchChronologicalForMember($memberId, $startDate = null)
+    {
+        $where = $this->buildDateRangeWhere($memberId, $startDate, null);
+
+        $sql = 'SELECT * FROM ' . $this->table
+            . ' WHERE ' . $where
+            . ' ORDER BY measurement_date ASC';
+
+        $rows = $this->db->get_rows($sql);
+
+        return is_array($rows) ? $rows : [];
+    }
+
+    public function fetchLatestForMember($memberId)
+    {
+        $sql = 'SELECT * FROM ' . $this->table
+            . ' WHERE member_id = ' . $this->db->pdb($memberId)
+            . ' ORDER BY measurement_date DESC LIMIT 1';
+
+        $row = $this->db->get_row($sql);
+
+        return is_array($row) ? $row : null;
+    }
+
+    public function findForMember($memberId, $measurementId)
+    {
+        $sql = 'SELECT * FROM ' . $this->table
+            . ' WHERE measurement_id = ' . $this->db->pdb($measurementId)
+            . ' AND member_id = ' . $this->db->pdb($memberId)
+            . ' LIMIT 1';
+
+        $row = $this->db->get_row($sql);
+
+        return is_array($row) ? $row : null;
+    }
+
+    public function deleteById($measurementId)
+    {
+        $result = $this->db->delete($this->table, 'measurement_id', $measurementId, 1);
+
+        if ($result === false) {
+            return false;
+        }
+
+        return $result > 0;
+    }
+
+    public function createMeasurement($memberId, array $data)
+    {
+        $insert = $this->prepareInsertData($memberId, $data);
+
+        $columns = array_keys($insert);
+        $values = array();
+
+        foreach ($insert as $value) {
+            $values[] = $this->db->pdb($value);
+        }
+
+        $sql = 'INSERT INTO ' . $this->table
+            . ' (' . implode(',', $columns) . ')'
+            . ' VALUES (' . implode(',', $values) . ')';
+
+        $insertId = $this->db->execute($sql);
+
+        if ($insertId === false) {
+            return false;
+        }
+
+        return $this->findForMember($memberId, (int)$insertId);
+    }
+
+    public function countCreatedSince($memberId, $since)
+    {
+        if ($this->isDateTime($since)) {
+            $since = $since->format('Y-m-d H:i:s');
+        }
+
+        $sql = 'SELECT COUNT(*) FROM ' . $this->table
+            . ' WHERE member_id = ' . $this->db->pdb($memberId)
+            . ' AND created_at >= ' . $this->db->pdb($since);
+
+        $count = $this->db->get_count($sql);
+
+        if (!is_int($count)) {
+            return 0;
+        }
+
+        return $count;
+    }
+
+    private function prepareInsertData($memberId, array $data)
+    {
+        $insert = array(
+            'member_id' => $memberId,
+        );
+
+        $columns = array(
+            'weight_kg',
+            'bmi',
+            'body_fat_percent',
+            'muscle_percent',
+            'moisture_percent',
+            'bone_mass',
+            'protein_percent',
+            'bmr',
+            'visceral_fat',
+            'skeletal_muscle_percent',
+            'physical_age',
+            'measurement_date',
+            'created_at',
+            'updated_at',
+        );
+
+        foreach ($columns as $column) {
+            if (!array_key_exists($column, $data)) {
+                $insert[$column] = null;
+                continue;
+            }
+
+            $value = $data[$column];
+
+            if ($this->isDateTime($value)) {
+                $value = $value->format('Y-m-d H:i:s');
+            }
+
+            $insert[$column] = $value;
+        }
+
+        return $insert;
+    }
+
+    private function buildDateRangeWhere($memberId, $startDate = null, $endDate = null)
+    {
+        $clauses = array('member_id = ' . $this->db->pdb($memberId));
+
+        if ($startDate !== null) {
+            if ($this->isDateTime($startDate)) {
+                $startDate = $startDate->format('Y-m-d H:i:s');
+            }
+
+            $clauses[] = 'measurement_date >= ' . $this->db->pdb($startDate);
+        }
+
+        if ($endDate !== null) {
+            if ($this->isDateTime($endDate)) {
+                $endDate = $endDate->format('Y-m-d H:i:s');
+            }
+
+            $clauses[] = 'measurement_date <= ' . $this->db->pdb($endDate);
+        }
+
+        return implode(' AND ', $clauses);
+    }
+
+    private function isDateTime($value)
+    {
+        return ($value instanceof DateTimeImmutable) || ($value instanceof DateTime);
+    }
+}
+

--- a/perch/addons/apps/api/routes/weight-measurements/helpers.php
+++ b/perch/addons/apps/api/routes/weight-measurements/helpers.php
@@ -1,0 +1,154 @@
+<?php
+if (!function_exists('wl_weight_measurements_table')) {
+    function wl_weight_measurements_table()
+    {
+        return PERCH_DB_PREFIX . 'weight_measurements';
+    }
+}
+
+if (!function_exists('wl_weight_measurement_percent_fields')) {
+    function wl_weight_measurement_percent_fields()
+    {
+        return [
+            'body_fat_percent',
+            'muscle_percent',
+            'moisture_percent',
+            'protein_percent',
+            'skeletal_muscle_percent',
+        ];
+    }
+}
+
+if (!function_exists('wl_cast_float')) {
+    function wl_cast_float($value)
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (float)$value;
+    }
+}
+
+if (!function_exists('wl_cast_int')) {
+    function wl_cast_int($value)
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (int)$value;
+    }
+}
+
+if (!function_exists('wl_format_datetime')) {
+    function wl_format_datetime($value)
+    {
+        if (!$value) {
+            return null;
+        }
+
+        try {
+            $dt = new DateTimeImmutable($value);
+            return $dt->setTimezone(new DateTimeZone('UTC'))->format(DateTime::ATOM);
+        } catch (Exception $e) {
+            return $value;
+        }
+    }
+}
+
+if (!function_exists('wl_format_measurement')) {
+    function wl_format_measurement(array $row, $includeBodyComposition = true)
+    {
+        $measurement = [
+            'id' => isset($row['measurement_id']) ? (int)$row['measurement_id'] : null,
+            'weight_kg' => wl_cast_float($row['weight_kg'] ?? null),
+            'bmi' => wl_cast_float($row['bmi'] ?? null),
+            'body_fat_percent' => wl_cast_float($row['body_fat_percent'] ?? null),
+            'muscle_percent' => wl_cast_float($row['muscle_percent'] ?? null),
+            'moisture_percent' => wl_cast_float($row['moisture_percent'] ?? null),
+            'bone_mass' => wl_cast_float($row['bone_mass'] ?? null),
+            'protein_percent' => wl_cast_float($row['protein_percent'] ?? null),
+            'bmr' => wl_cast_int($row['bmr'] ?? null),
+            'visceral_fat' => wl_cast_float($row['visceral_fat'] ?? null),
+            'skeletal_muscle_percent' => wl_cast_float($row['skeletal_muscle_percent'] ?? null),
+            'physical_age' => wl_cast_int($row['physical_age'] ?? null),
+            'measurement_date' => wl_format_datetime($row['measurement_date'] ?? null),
+            'created_at' => wl_format_datetime($row['created_at'] ?? null),
+            'updated_at' => wl_format_datetime($row['updated_at'] ?? null),
+        ];
+
+        if (!$includeBodyComposition) {
+            foreach ([
+                'body_fat_percent',
+                'muscle_percent',
+                'moisture_percent',
+                'bone_mass',
+                'protein_percent',
+                'skeletal_muscle_percent',
+                'visceral_fat',
+            ] as $field) {
+                unset($measurement[$field]);
+            }
+        }
+
+        return $measurement;
+    }
+}
+
+if (!function_exists('wl_parse_bool')) {
+    function wl_parse_bool($value, $default = false)
+    {
+        if ($value === null) {
+            return $default;
+        }
+
+        $filtered = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        if ($filtered === null) {
+            return $default;
+        }
+
+        return $filtered;
+    }
+}
+
+if (!function_exists('wl_determine_trend')) {
+    function wl_determine_trend($start, $end, $threshold = 0.1)
+    {
+        if ($start === null || $end === null) {
+            return 'unknown';
+        }
+
+        $difference = (float)$end - (float)$start;
+        if (abs($difference) <= $threshold) {
+            return 'stable';
+        }
+
+        return $difference > 0 ? 'increasing' : 'decreasing';
+    }
+}
+
+if (!function_exists('wl_weight_measurements_error')) {
+    function wl_weight_measurements_error($statusCode, $message)
+    {
+        http_response_code($statusCode);
+        echo json_encode(['error' => $message]);
+        exit;
+    }
+}
+
+require_once __DIR__ . '/WeightMeasurementsRepository.php';
+
+if (!function_exists('wl_weight_measurements_repository')) {
+    function wl_weight_measurements_repository()
+    {
+        static $repository = null;
+
+        if ($repository === null) {
+            $repository = new WeightMeasurementsRepository();
+        }
+
+        return $repository;
+    }
+}

--- a/perch/addons/apps/api/routes/weight-measurements/index.php
+++ b/perch/addons/apps/api/routes/weight-measurements/index.php
@@ -1,0 +1,310 @@
+<?php
+include(__DIR__ . '/../../../../../core/runtime/runtime.php');
+
+require_once __DIR__ . '/../../auth.php';
+require_once __DIR__ . '/helpers.php';
+
+$token = get_bearer_token();
+$payload = verify_token($token);
+
+if (!$payload) {
+    wl_weight_measurements_error(401, 'Unauthorized');
+}
+
+$memberId = $payload['user_id'];
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+
+switch ($method) {
+    case 'GET':
+        wl_handle_weight_measurements_list($memberId);
+        break;
+    case 'POST':
+        wl_handle_weight_measurements_create($memberId);
+        break;
+    case 'DELETE':
+        wl_handle_weight_measurements_delete($memberId);
+        break;
+    default:
+        header('Allow: GET, POST, DELETE');
+        wl_weight_measurements_error(405, 'Method not allowed');
+}
+
+function wl_handle_weight_measurements_list($memberId)
+{
+    global $_ROUTE;
+
+    if (!empty($_ROUTE['params'])) {
+        wl_weight_measurements_error(404, 'Endpoint not found');
+    }
+
+    $pageParam = $_GET['page'] ?? 1;
+    $page = filter_var($pageParam, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+    if ($page === false) {
+        wl_weight_measurements_error(400, 'page must be an integer greater than or equal to 1.');
+    }
+
+    $limitParam = $_GET['limit'] ?? 30;
+    $limit = filter_var($limitParam, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+    if ($limit === false) {
+        wl_weight_measurements_error(400, 'limit must be an integer greater than or equal to 1.');
+    }
+
+    $limit = min($limit, 100);
+    $includeBodyComposition = wl_parse_bool($_GET['include_body_composition'] ?? null, true);
+
+    $utc = new DateTimeZone('UTC');
+    $startDate = null;
+    $endDate = null;
+
+    if (isset($_GET['start_date']) && $_GET['start_date'] !== '') {
+        try {
+            $startDate = new DateTimeImmutable($_GET['start_date']);
+            $startDate = $startDate->setTimezone($utc);
+        } catch (Exception $e) {
+            wl_weight_measurements_error(400, 'start_date must be a valid ISO 8601 date.');
+        }
+    }
+
+    if (isset($_GET['end_date']) && $_GET['end_date'] !== '') {
+        try {
+            $endDate = new DateTimeImmutable($_GET['end_date']);
+            $endDate = $endDate->setTimezone($utc);
+        } catch (Exception $e) {
+            wl_weight_measurements_error(400, 'end_date must be a valid ISO 8601 date.');
+        }
+    }
+
+    if ($startDate && $endDate && $startDate > $endDate) {
+        wl_weight_measurements_error(400, 'start_date must be before end_date.');
+    }
+
+    $repository = wl_weight_measurements_repository();
+
+    $offset = ($page - 1) * $limit;
+    $total = $repository->countForMember($memberId, $startDate, $endDate);
+    $rows = $repository->fetchPageForMember($memberId, $limit, $offset, $startDate, $endDate);
+
+    $measurements = [];
+    foreach ($rows as $row) {
+        $measurements[] = wl_format_measurement($row, $includeBodyComposition);
+    }
+
+    $totalPages = $total > 0 ? (int)ceil($total / $limit) : 0;
+
+    $response = [
+        'page' => $page,
+        'limit' => $limit,
+        'total' => $total,
+        'total_pages' => $totalPages,
+        'has_next' => $totalPages > 0 ? $page < $totalPages : false,
+        'has_previous' => $page > 1,
+        'data' => $measurements,
+    ];
+
+    echo json_encode($response);
+    exit;
+}
+
+function wl_handle_weight_measurements_create($memberId)
+{
+    $raw = file_get_contents('php://input');
+    $data = json_decode($raw, true);
+
+    if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
+        wl_weight_measurements_error(400, 'Request body must be valid JSON.');
+    }
+
+    if (!is_array($data)) {
+        $data = [];
+    }
+
+    [$errors, $sanitized] = wl_validate_weight_measurement_payload($data);
+
+    if (!empty($errors)) {
+        http_response_code(422);
+        echo json_encode(['errors' => $errors]);
+        exit;
+    }
+
+    if (wl_weight_measurements_rate_limit_exceeded($memberId, $sanitized['created_at'])) {
+        wl_weight_measurements_error(429, 'Rate limit exceeded. You can submit up to 10 measurements per hour.');
+    }
+
+    $repository = wl_weight_measurements_repository();
+    $measurement = $repository->createMeasurement($memberId, $sanitized);
+
+    if (!is_array($measurement)) {
+        wl_weight_measurements_error(500, 'Unable to save measurement.');
+    }
+
+    http_response_code(201);
+    echo json_encode(wl_format_measurement($measurement));
+    exit;
+}
+
+function wl_handle_weight_measurements_delete($memberId)
+{
+    global $_ROUTE;
+
+    $idParam = null;
+    if (!empty($_ROUTE['params'])) {
+        $idParam = $_ROUTE['params'][0];
+    }
+
+    if ($idParam === null && isset($_GET['id'])) {
+        $idParam = $_GET['id'];
+    }
+
+    if ($idParam === null || $idParam === '') {
+        wl_weight_measurements_error(400, 'Measurement ID is required.');
+    }
+
+    if (!ctype_digit((string)$idParam)) {
+        wl_weight_measurements_error(400, 'Measurement ID must be a positive integer.');
+    }
+
+    $measurementId = (int)$idParam;
+    if ($measurementId <= 0) {
+        wl_weight_measurements_error(400, 'Measurement ID must be a positive integer.');
+    }
+
+    $repository = wl_weight_measurements_repository();
+    $measurement = $repository->findForMember($memberId, $measurementId);
+
+    if (!is_array($measurement)) {
+        wl_weight_measurements_error(404, 'Measurement not found.');
+    }
+
+    $deleted = $repository->deleteById($measurementId);
+    if (!$deleted) {
+        wl_weight_measurements_error(500, 'Unable to delete measurement.');
+    }
+
+    http_response_code(204);
+    exit;
+}
+
+function wl_validate_weight_measurement_payload(array $input)
+{
+    $errors = [];
+    $utc = new DateTimeZone('UTC');
+    $now = new DateTimeImmutable('now', $utc);
+
+    $sanitized = [
+        'weight_kg' => null,
+        'bmi' => null,
+        'body_fat_percent' => null,
+        'muscle_percent' => null,
+        'moisture_percent' => null,
+        'bone_mass' => null,
+        'protein_percent' => null,
+        'bmr' => null,
+        'visceral_fat' => null,
+        'skeletal_muscle_percent' => null,
+        'physical_age' => null,
+        'measurement_date' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ];
+
+    if (!array_key_exists('weight_kg', $input)) {
+        $errors[] = 'weight_kg is required.';
+    } elseif (!is_numeric($input['weight_kg'])) {
+        $errors[] = 'weight_kg must be a number.';
+    } else {
+        $weight = (float)$input['weight_kg'];
+        if ($weight < 10 || $weight > 500) {
+            $errors[] = 'weight_kg must be between 10 and 500.';
+        } else {
+            $sanitized['weight_kg'] = $weight;
+        }
+    }
+
+    $floatRules = [
+        'bmi' => [10, 100],
+        'body_fat_percent' => [3, 80],
+        'muscle_percent' => [0, 100],
+        'moisture_percent' => [0, 100],
+        'bone_mass' => [0, 20],
+        'protein_percent' => [0, 100],
+        'visceral_fat' => [0, 50],
+        'skeletal_muscle_percent' => [0, 100],
+    ];
+
+    foreach ($floatRules as $field => [$min, $max]) {
+        if (array_key_exists($field, $input) && $input[$field] !== null && $input[$field] !== '') {
+            if (!is_numeric($input[$field])) {
+                $errors[] = $field . ' must be a number.';
+                continue;
+            }
+
+            $value = (float)$input[$field];
+            if ($value < $min || $value > $max) {
+                $errors[] = $field . ' must be between ' . $min . ' and ' . $max . '.';
+                continue;
+            }
+
+            $sanitized[$field] = $value;
+        }
+    }
+
+    $intRules = [
+        'bmr' => [0, 10000],
+        'physical_age' => [0, 150],
+    ];
+
+    foreach ($intRules as $field => [$min, $max]) {
+        if (array_key_exists($field, $input) && $input[$field] !== null && $input[$field] !== '') {
+            if (!is_numeric($input[$field])) {
+                $errors[] = $field . ' must be an integer.';
+                continue;
+            }
+
+            $value = (int)$input[$field];
+            if ($value < $min || $value > $max) {
+                $errors[] = $field . ' must be between ' . $min . ' and ' . $max . '.';
+                continue;
+            }
+
+            $sanitized[$field] = $value;
+        }
+    }
+
+    if (array_key_exists('measurement_date', $input) && $input['measurement_date'] !== null && $input['measurement_date'] !== '') {
+        try {
+            $measurementDate = new DateTimeImmutable($input['measurement_date']);
+            $sanitized['measurement_date'] = $measurementDate->setTimezone($utc);
+        } catch (Exception $e) {
+            $errors[] = 'measurement_date must be a valid ISO 8601 datetime.';
+        }
+    }
+
+    if (!$sanitized['measurement_date']) {
+        $sanitized['measurement_date'] = $now;
+    }
+
+    $percentValues = [];
+    foreach (wl_weight_measurement_percent_fields() as $field) {
+        if ($sanitized[$field] !== null) {
+            $percentValues[] = $sanitized[$field];
+        }
+    }
+
+    if (!empty($percentValues)) {
+        $sum = array_sum($percentValues);
+        if (abs($sum - 100) > 5) {
+            $errors[] = 'Body composition percentages should total approximately 100%.';
+        }
+    }
+
+    return [$errors, $sanitized];
+}
+
+function wl_weight_measurements_rate_limit_exceeded($memberId, DateTimeImmutable $now)
+{
+    $repository = wl_weight_measurements_repository();
+    $windowStart = $now->sub(new DateInterval('PT1H'));
+    $count = $repository->countCreatedSince($memberId, $windowStart);
+
+    return $count >= 10;
+}

--- a/perch/addons/apps/api/routes/weight-measurements/latest.php
+++ b/perch/addons/apps/api/routes/weight-measurements/latest.php
@@ -1,0 +1,23 @@
+<?php
+include(__DIR__ . '/../../../../../core/runtime/runtime.php');
+
+require_once __DIR__ . '/../../auth.php';
+require_once __DIR__ . '/helpers.php';
+
+$token = get_bearer_token();
+$payload = verify_token($token);
+
+if (!$payload) {
+    wl_weight_measurements_error(401, 'Unauthorized');
+}
+
+$memberId = $payload['user_id'];
+$repository = wl_weight_measurements_repository();
+$measurement = $repository->fetchLatestForMember($memberId);
+
+if (!is_array($measurement)) {
+    wl_weight_measurements_error(404, 'No measurements found.');
+}
+
+echo json_encode(wl_format_measurement($measurement));
+exit;

--- a/perch/addons/apps/api/routes/weight-measurements/stats.php
+++ b/perch/addons/apps/api/routes/weight-measurements/stats.php
@@ -1,0 +1,214 @@
+<?php
+include(__DIR__ . '/../../../../../core/runtime/runtime.php');
+
+require_once __DIR__ . '/../../auth.php';
+require_once __DIR__ . '/helpers.php';
+
+$token = get_bearer_token();
+$payload = verify_token($token);
+
+if (!$payload) {
+    wl_weight_measurements_error(401, 'Unauthorized');
+}
+
+$periodParam = $_GET['period'] ?? 'month';
+$metricParam = $_GET['metric'] ?? 'all';
+
+$allowedPeriods = [
+    'week' => new DateInterval('P7D'),
+    'month' => new DateInterval('P1M'),
+    '3months' => new DateInterval('P3M'),
+    '6months' => new DateInterval('P6M'),
+    'year' => new DateInterval('P1Y'),
+    'all' => null,
+];
+
+if (!array_key_exists($periodParam, $allowedPeriods)) {
+    wl_weight_measurements_error(400, 'Invalid period.');
+}
+
+$allowedMetrics = ['weight', 'bmi', 'body_fat', 'muscle', 'all'];
+if (!in_array($metricParam, $allowedMetrics, true)) {
+    wl_weight_measurements_error(400, 'Invalid metric.');
+}
+
+$utc = new DateTimeZone('UTC');
+$now = new DateTimeImmutable('now', $utc);
+$startDate = null;
+
+if ($periodParam !== 'all') {
+    $interval = $allowedPeriods[$periodParam];
+    $startDate = $now->sub($interval);
+}
+
+$memberId = $payload['user_id'];
+$repository = wl_weight_measurements_repository();
+$rows = $repository->fetchChronologicalForMember($memberId, $startDate);
+
+if (empty($rows)) {
+    echo json_encode([
+        'period' => $periodParam,
+        'data_points' => [],
+        'summary' => [
+            'start_weight' => null,
+            'current_weight' => null,
+            'weight_change' => null,
+            'weight_change_percent' => null,
+            'average_weekly_change' => null,
+            'measurements_count' => 0,
+        ],
+        'trends' => [
+            'weight' => 'unknown',
+            'body_fat' => 'unknown',
+            'muscle' => 'unknown',
+        ],
+    ]);
+    exit;
+}
+
+$fieldsForDaily = ['weight_kg', 'bmi', 'body_fat_percent', 'muscle_percent'];
+$daily = [];
+$firstRow = null;
+$lastRow = null;
+
+foreach ($rows as $row) {
+    try {
+        $date = new DateTimeImmutable($row['measurement_date']);
+    } catch (Exception $e) {
+        continue;
+    }
+
+    $date = $date->setTimezone($utc);
+    $dayKey = $date->format('Y-m-d');
+
+    if (!isset($daily[$dayKey])) {
+        $daily[$dayKey] = [
+            'sums' => array_fill_keys($fieldsForDaily, 0.0),
+            'counts' => array_fill_keys($fieldsForDaily, 0),
+        ];
+    }
+
+    foreach ($fieldsForDaily as $field) {
+        if (isset($row[$field]) && $row[$field] !== null && $row[$field] !== '') {
+            $daily[$dayKey]['sums'][$field] += (float)$row[$field];
+            $daily[$dayKey]['counts'][$field] += 1;
+        }
+    }
+
+    if ($firstRow === null) {
+        $firstRow = $row;
+    }
+    $lastRow = $row;
+}
+
+ksort($daily);
+
+$metricFieldMap = [
+    'weight' => 'weight_kg',
+    'bmi' => 'bmi',
+    'body_fat' => 'body_fat_percent',
+    'muscle' => 'muscle_percent',
+];
+
+$fieldsToInclude = $metricParam === 'all'
+    ? $fieldsForDaily
+    : [$metricFieldMap[$metricParam]];
+
+$dataPoints = [];
+foreach ($daily as $day => $aggregate) {
+    $point = ['date' => $day];
+    foreach ($fieldsToInclude as $field) {
+        if ($aggregate['counts'][$field] > 0) {
+            $point[$field] = round($aggregate['sums'][$field] / $aggregate['counts'][$field], 3);
+        } else {
+            $point[$field] = null;
+        }
+    }
+    $dataPoints[] = $point;
+}
+
+$summary = wl_build_weight_measurement_summary($firstRow, $lastRow, count($rows), $utc);
+$trends = wl_build_weight_measurement_trends($firstRow, $lastRow);
+
+echo json_encode([
+    'period' => $periodParam,
+    'data_points' => $dataPoints,
+    'summary' => $summary,
+    'trends' => $trends,
+]);
+
+exit;
+
+function wl_build_weight_measurement_summary($firstRow, $lastRow, $count, DateTimeZone $utc)
+{
+    $startWeight = (is_array($firstRow) && isset($firstRow['weight_kg']) && $firstRow['weight_kg'] !== null)
+        ? (float)$firstRow['weight_kg']
+        : null;
+    $currentWeight = (is_array($lastRow) && isset($lastRow['weight_kg']) && $lastRow['weight_kg'] !== null)
+        ? (float)$lastRow['weight_kg']
+        : null;
+
+    $weightChange = null;
+    $weightChangePercent = null;
+    $averageWeeklyChange = null;
+
+    if ($startWeight !== null && $currentWeight !== null) {
+        $weightChange = round($currentWeight - $startWeight, 3);
+        if ($startWeight > 0) {
+            $weightChangePercent = round(($weightChange / $startWeight) * 100, 3);
+        }
+
+        try {
+            if (is_array($firstRow) && isset($firstRow['measurement_date']) && is_array($lastRow) && isset($lastRow['measurement_date'])) {
+                $firstDate = new DateTimeImmutable($firstRow['measurement_date']);
+                $lastDate = new DateTimeImmutable($lastRow['measurement_date']);
+                $firstDate = $firstDate->setTimezone($utc);
+                $lastDate = $lastDate->setTimezone($utc);
+                $days = max($firstDate->diff($lastDate)->days, 1);
+                $weeks = max($days / 7, 1);
+                $averageWeeklyChange = round($weightChange / $weeks, 3);
+            }
+        } catch (Exception $e) {
+            $averageWeeklyChange = null;
+        }
+    }
+
+    return [
+        'start_weight' => $startWeight,
+        'current_weight' => $currentWeight,
+        'weight_change' => $weightChange,
+        'weight_change_percent' => $weightChangePercent,
+        'average_weekly_change' => $averageWeeklyChange,
+        'measurements_count' => (int)$count,
+    ];
+}
+
+function wl_build_weight_measurement_trends($firstRow, $lastRow)
+{
+    $startWeight = (is_array($firstRow) && isset($firstRow['weight_kg']) && $firstRow['weight_kg'] !== null)
+        ? (float)$firstRow['weight_kg']
+        : null;
+    $currentWeight = (is_array($lastRow) && isset($lastRow['weight_kg']) && $lastRow['weight_kg'] !== null)
+        ? (float)$lastRow['weight_kg']
+        : null;
+
+    $startBodyFat = (is_array($firstRow) && isset($firstRow['body_fat_percent']) && $firstRow['body_fat_percent'] !== null)
+        ? (float)$firstRow['body_fat_percent']
+        : null;
+    $currentBodyFat = (is_array($lastRow) && isset($lastRow['body_fat_percent']) && $lastRow['body_fat_percent'] !== null)
+        ? (float)$lastRow['body_fat_percent']
+        : null;
+
+    $startMuscle = (is_array($firstRow) && isset($firstRow['muscle_percent']) && $firstRow['muscle_percent'] !== null)
+        ? (float)$firstRow['muscle_percent']
+        : null;
+    $currentMuscle = (is_array($lastRow) && isset($lastRow['muscle_percent']) && $lastRow['muscle_percent'] !== null)
+        ? (float)$lastRow['muscle_percent']
+        : null;
+
+    return [
+        'weight' => wl_determine_trend($startWeight, $currentWeight),
+        'body_fat' => wl_determine_trend($startBodyFat, $currentBodyFat),
+        'muscle' => wl_determine_trend($startMuscle, $currentMuscle),
+    ];
+}


### PR DESCRIPTION
## Summary
- add a WeightMeasurementsRepository class to encapsulate querying and persistence logic for the weight measurements table
- expose a shared repository helper and refactor list/create/delete/latest/stats routes to use it, including rate limit checks

## Testing
- php -l perch/addons/apps/api/routes/weight-measurements/helpers.php
- php -l perch/addons/apps/api/routes/weight-measurements/WeightMeasurementsRepository.php
- php -l perch/addons/apps/api/routes/weight-measurements/index.php
- php -l perch/addons/apps/api/routes/weight-measurements/latest.php
- php -l perch/addons/apps/api/routes/weight-measurements/stats.php

------
https://chatgpt.com/codex/tasks/task_b_68d2a8782dbc83249f8e9870338707ae