### PR TITLE
Support custom weight measurements table name

### DIFF
--- a/perch/addons/apps/api/routes/weight-measurements/WeightMeasurementsRepository.php
+++ b/perch/addons/apps/api/routes/weight-measurements/WeightMeasurementsRepository.php
@@ -5,10 +5,26 @@ class WeightMeasurementsRepository
     private $db;
     private $table;
 
-    public function __construct($db = null)
+    public function __construct($db = null, $table = null)
     {
-        $this->db = $db ?: PerchDB::fetch();
-        $this->table = wl_weight_measurements_table();
+        if (is_string($db) && $db !== '' && $table === null) {
+            $table = $db;
+            $db = null;
+        }
+
+        if ($db === null) {
+            $this->db = PerchDB::fetch();
+        } elseif (is_object($db)) {
+            $this->db = $db;
+        } else {
+            $this->db = PerchDB::fetch($db);
+        }
+
+        if (is_string($table) && $table !== '') {
+            $this->table = $this->resolveTableName($table);
+        } else {
+            $this->table = wl_weight_measurements_table();
+        }
     }
 
     public function countForMember($memberId, $startDate = null, $endDate = null)
@@ -190,6 +206,19 @@ class WeightMeasurementsRepository
         }
 
         return implode(' AND ', $clauses);
+    }
+
+    private function resolveTableName($table)
+    {
+        if (!defined('PERCH_DB_PREFIX') || PERCH_DB_PREFIX === '') {
+            return $table;
+        }
+
+        if (strpos($table, PERCH_DB_PREFIX) === 0) {
+            return $table;
+        }
+
+        return PERCH_DB_PREFIX . $table;
     }
 
     private function isDateTime($value)

--- a/perch/addons/apps/api/routes/weight-measurements/helpers.php
+++ b/perch/addons/apps/api/routes/weight-measurements/helpers.php
@@ -2,7 +2,7 @@
 if (!function_exists('wl_weight_measurements_table')) {
     function wl_weight_measurements_table()
     {
-        return PERCH_DB_PREFIX . 'weight_measurements';
+        return PERCH_DB_PREFIX . 'getweightloss_measurements';
     }
 }
 
@@ -146,7 +146,7 @@ if (!function_exists('wl_weight_measurements_repository')) {
         static $repository = null;
 
         if ($repository === null) {
-            $repository = new WeightMeasurementsRepository("getweightloss_measurements");
+            $repository = new WeightMeasurementsRepository(null, 'getweightloss_measurements');
         }
 
         return $repository;


### PR DESCRIPTION
## Summary
- update `WeightMeasurementsRepository` to accept an optional table argument, normalising any prefix while keeping a valid Perch DB connection
- point the weight measurements helper at the `getweightloss_measurements` table via the new constructor signature

## Testing
- php -l perch/addons/apps/api/routes/weight-measurements/WeightMeasurementsRepository.php
- php -l perch/addons/apps/api/routes/weight-measurements/helpers.php

------
https://chatgpt.com/codex/tasks/task_b_68d2d62439a8832497690148026bbade