### PR TITLE
Handle medication-specific recent dose inputs

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
@@ -1,11 +1,93 @@
 <?php
 
+require_once __DIR__ . '/questionnaire_medication_helpers.php';
+
 class PerchMembers_Questionnaires extends PerchAPI_Factory
 {
     protected $table     = 'questionnaire';
-	protected $pk        = 'id';
-	protected $singular_classname = 'PerchMembers_Questionnaire';
-	public $reorder_questions=[
+        protected $pk        = 'id';
+        protected $singular_classname = 'PerchMembers_Questionnaire';
+        protected $medicationSlugs;
+        public function __construct($api = null)
+        {
+            parent::__construct($api);
+
+            $doseOptions = [
+                'less4' => 'Less than 4 weeks ago',
+                '4to6' => '4-6 weeks ago',
+                'over6' => 'More than 6 weeks ago',
+            ];
+
+            foreach ($this->getMedicationSlugs() as $slug) {
+                $label = $this->getMedicationLabel($slug);
+                $weightLabel = 'What was your weight in kg/st-lbs before starting ' . $label . '?';
+                $lastDoseLabel = 'When was your last dose of ' . $label . '?';
+                $recentDoseLabel = 'What dose of ' . $label . ' were you prescribed most recently?';
+
+                $this->steps["weight-{$slug}"] = 'starting_wegovy';
+                $this->steps["unit-{$slug}"] = 'starting_wegovy';
+                $this->steps["weight2-{$slug}"] = 'starting_wegovy';
+                $this->steps["dose-{$slug}"] = 'dose_wegovy';
+                $this->steps["recently-dose-{$slug}"] = 'recently_wegovy';
+
+                $this->questions["weight-{$slug}"] = $weightLabel;
+                $this->questions["dose-{$slug}"] = $lastDoseLabel;
+                $this->questions["recently-dose-{$slug}"] = $recentDoseLabel;
+
+                $this->questions_and_answers["weight-{$slug}"] = [
+                    'label' => $weightLabel,
+                    'type' => 'text',
+                    'name' => "weight-{$slug}",
+                ];
+
+                $this->questions_and_answers["dose-{$slug}"] = [
+                    'label' => $lastDoseLabel,
+                    'type' => 'radio',
+                    'name' => "dose-{$slug}",
+                    'options' => $doseOptions,
+                ];
+
+                $recentDoseOptions = perch_questionnaire_recent_dose_options($slug);
+                $recentDoseField = [
+                    'label' => $recentDoseLabel,
+                    'name' => "recently-dose-{$slug}",
+                ];
+
+                if ($recentDoseOptions !== null) {
+                    $recentDoseField['type'] = 'radio';
+                    $recentDoseField['options'] = $recentDoseOptions;
+                } else {
+                    $recentDoseField['type'] = 'text';
+                }
+
+                $this->questions_and_answers["recently-dose-{$slug}"] = $recentDoseField;
+            }
+        }
+
+        protected function getMedicationSlugs(): array
+        {
+            if ($this->medicationSlugs === null) {
+                $options = perch_questionnaire_medications();
+                $slugs = [];
+                foreach ($options as $slug => $label) {
+                    if ($slug === 'none') {
+                        continue;
+                    }
+                    $slugs[] = $slug;
+                }
+
+                $this->medicationSlugs = $slugs;
+            }
+
+            return $this->medicationSlugs;
+        }
+
+        protected function getMedicationLabel(string $slug): string
+        {
+            return perch_questionnaire_medication_label($slug);
+        }
+
+        public $reorder_questions=[
 	"weight"=>"What is your weight?",
 	"weight2"=>"inches",
 	"weightunit"=>"weight unit",
@@ -415,16 +497,6 @@ class PerchMembers_Questionnaires extends PerchAPI_Factory
     "documents"=>"Member Documents",
     "bmi"=>"BMI",
     ];
-public $doses = [
-    '25mg' => '0.25mg/2.5mg',
-    '05mg' => '0.5mg/5mg',
-    '1mg'  => '1mg/7.5mg',
-    '17mg' => '1.7mg/12.5mg',
-    '24mg' => '2.4mg/15mg',
-    'other'=> 'Other'
-];
-
-
    /* protected $required_answers=[
     "age"=>["18to74"],
     "ethnicity"=>["asian","Black (African/Caribbean)"],
@@ -634,19 +706,28 @@ function getNextStepforFirstOrder(array $data): string {
 
        }
            if ($step=="medications" ){
-           if (is_array($value) &&!empty(array_intersect(['wegovy','ozempic','saxenda','rybelsus','mounjaro','alli','mysimba','other'], $value))) {
+           if (is_array($value) && !empty(array_intersect($this->getMedicationSlugs(), array_map('perch_questionnaire_medication_slug', (array)$value)))) {
             return true;
            }
            }
 
-              if ($step=="starting_wegovy" || $step=="unit-wegovy" || $step=="weight2-wegovy" ||  $step=="weight-wegovy"){
+              if ($step=="starting_wegovy"){
 
                      return true;
                      }
 
-                     if ($step==="dose-wegovy" || $step=="recently-dose-wegovy") {
-
-                         return true;
+                     if (is_string($step)) {
+                         foreach ($this->getMedicationSlugs() as $slug) {
+                             if (
+                                 $step === "unit-{$slug}" ||
+                                 $step === "weight2-{$slug}" ||
+                                 $step === "weight-{$slug}" ||
+                                 $step === "dose-{$slug}" ||
+                                 $step === "recently-dose-{$slug}"
+                             ) {
+                                 return true;
+                             }
+                         }
                      }
 
                      if ($step=="recently_wegovy") {
@@ -781,19 +862,33 @@ function getNextStepforFirstOrder(array $data): string {
           }
 
           // If 'wegovy' selected, check extra info
-          if (in_array('wegovy', $data['medications'])) {
-              if (empty($data['weight-wegovy'])) {
-                  $errors[] = 'Please provide your weight before starting Wegovy.';
+          $selectedMedicationSlugs = is_array($data['medications'])
+              ? array_map('perch_questionnaire_medication_slug', $data['medications'])
+              : [];
+
+          foreach ($this->getMedicationSlugs() as $medicationSlug) {
+              if (!in_array($medicationSlug, $selectedMedicationSlugs, true)) {
+                  continue;
               }
 
-              if (empty($data['dose-wegovy'])) {
-                  $errors[] = 'Please indicate your last dose of Wegovy.';
+              $label = $this->getMedicationLabel($medicationSlug);
+              $weightKey = "weight-{$medicationSlug}";
+              if (empty($data[$weightKey])) {
+                  $errors[] = 'Please provide your weight before starting ' . $label . '.';
               }
 
-              if (empty($data['recently-dose-wegovy'])) {
-                  $errors[] = 'Please provide the most recent dose prescribed.';
+              $doseKey = "dose-{$medicationSlug}";
+              if (empty($data[$doseKey])) {
+                  $errors[] = 'Please indicate your last dose of ' . $label . '.';
               }
 
+              $recentDoseKey = "recently-dose-{$medicationSlug}";
+              if (empty($data[$recentDoseKey])) {
+                  $errors[] = 'Please provide the most recent dose prescribed for ' . $label . '.';
+              }
+          }
+
+          if (in_array('wegovy', $selectedMedicationSlugs, true)) {
               if (empty($data['continue-dose-wegovy'])) {
                   $errors[] = 'Please select your preferred continuation dose.';
               }
@@ -1025,13 +1120,25 @@ $out=[];
 
 
       $questionLookup = ($type=="first-order") ? $this->questions : $this->reorder_questions;
+      if ($type=="first-order") {
+          foreach ($this->getMedicationSlugs() as $slug) {
+              $label = $this->getMedicationLabel($slug);
+              $questionLookup["weight-{$slug}"] = "What was your weight in kg/st-lbs before starting " . $label . '?';
+              $questionLookup["dose-{$slug}"] = "When was your last dose of " . $label . '?';
+              $questionLookup["recently-dose-{$slug}"] = "What dose of " . $label . " were you prescribed most recently?";
+          }
+      }
       $questionConfigSet = ($type=="first-order") ? $this->questions_and_answers : $this->reorder_questions_answers;
 
+      $medicationUnits = [];
       if($type=="first-order"){
           $weightradiounit=$data["weightunit"] ?? '';
            $heightunitradio=$data["heightunit"] ?? '';
-           if(isset($data["unit-wegovy"])){
-           $unitwegovyradio=$data["unit-wegovy"];
+           foreach ($this->getMedicationSlugs() as $slug) {
+               $unitKey = "unit-{$slug}";
+               if (isset($data[$unitKey])) {
+                   $medicationUnits[$slug] = $data[$unitKey];
+               }
            }
       }
 
@@ -1071,19 +1178,25 @@ $out=[];
             }
             }
         }
-        if($key=="weight-wegovy" && isset($unitwegovyradio)){
-            $weightwegovyunit=explode("-",$unitwegovyradio);
-                if(count($weightwegovyunit)>1){
-                 $qdata['answer_text'].= " ".$weightwegovyunit[0];
-                  if(isset($data["weight2-wegovy"]) ){
-                         $qdata['answer_text'].= " ".$data["weight2-wegovy"]."  ".$weightwegovyunit[1];
-
+        if (strpos($key, 'weight-') === 0 && !empty($medicationUnits)) {
+            $slug = substr($key, 7);
+            if (isset($medicationUnits[$slug])) {
+                $unitParts = explode('-', $medicationUnits[$slug]);
+                if (count($unitParts) > 1) {
+                    $qdata['answer_text'] .= ' ' . $unitParts[0];
+                    $secondKey = "weight2-{$slug}";
+                    if (isset($data[$secondKey]) && $data[$secondKey] !== '') {
+                        $qdata['answer_text'] .= ' ' . $data[$secondKey] . '  ' . $unitParts[1];
                     }
-                    }
+                }
+            }
         }
-           if($key=="weight-wegovy" && isset($this->doses[$value])){
-
-            $qdata['answer_text']=$this->doses[$value];
+           if (strpos($key, 'recently-dose-') === 0) {
+            $medicationSlug = substr($key, strlen('recently-dose-'));
+            $recentDoseOptions = perch_questionnaire_recent_dose_options($medicationSlug);
+            if (is_array($recentDoseOptions) && isset($recentDoseOptions[$value])) {
+                $qdata['answer_text'] = $recentDoseOptions[$value];
+            }
         }
 
          if($key=="height"){

--- a/perch/addons/apps/perch_members/questionnaire_medication_helpers.php
+++ b/perch/addons/apps/perch_members/questionnaire_medication_helpers.php
@@ -1,0 +1,72 @@
+<?php
+
+if (!function_exists('perch_questionnaire_medications')) {
+    function perch_questionnaire_medications(): array
+    {
+        return [
+            'wegovy' => 'Wegovy',
+            'ozempic' => 'Ozempic',
+            'saxenda' => 'Saxenda',
+            'rybelsus' => 'Rybelsus',
+            'mounjaro' => 'Mounjaro',
+            'alli' => 'Alli',
+            'mysimba' => 'Mysimba',
+            'other' => 'the weight loss medication',
+            'none' => 'None',
+        ];
+    }
+}
+
+if (!function_exists('perch_questionnaire_medication_label')) {
+    function perch_questionnaire_medication_label(string $slug): string
+    {
+        $medications = perch_questionnaire_medications();
+        $key = strtolower($slug);
+        if (isset($medications[$key])) {
+            return $medications[$key];
+        }
+
+        $formatted = ucwords(str_replace(['-', '_'], ' ', $key));
+        return $formatted !== '' ? $formatted : 'the weight loss medication';
+    }
+}
+
+if (!function_exists('perch_questionnaire_medication_slug')) {
+    function perch_questionnaire_medication_slug(string $value): string
+    {
+        $value = strtolower($value);
+        $value = preg_replace('/[^a-z0-9]+/', '-', $value);
+        return trim($value, '-');
+    }
+}
+
+if (!function_exists('perch_questionnaire_recent_dose_options')) {
+    function perch_questionnaire_recent_dose_options(string $slug): ?array
+    {
+        $slug = perch_questionnaire_medication_slug($slug);
+
+        $defaultOptions = [
+            '25mg' => '0.25mg/2.5mg',
+            '05mg' => '0.5mg/5mg',
+            '1mg'  => '1mg/7.5mg',
+            '17mg' => '1.7mg/12.5mg',
+            '24mg' => '2.4mg/15mg',
+            'other' => 'Other',
+        ];
+
+        if ($slug === 'ozempic') {
+            return [
+                '0.25 mg' => '0.25 mg',
+                '0.5 mg' => '0.5 mg',
+                '1 mg' => '1 mg',
+                '2 mg' => '2 mg',
+            ];
+        }
+
+        if ($slug === 'wegovy' || $slug === 'mounjaro') {
+            return $defaultOptions;
+        }
+
+        return null;
+    }
+}

--- a/perch/templates/forms/questionnaire.html
+++ b/perch/templates/forms/questionnaire.html
@@ -1,4 +1,99 @@
 <perch:form id="questionnaire" method="POST" app="perch_forms" action="/get-started/questionnaire" >
+    <script type="application/json" id="medication-step-data"><perch:forms id="medication_weight_json" encode="false" /></script>
+    <script>
+        (function () {
+            if (window.getMedicationStepData) {
+                return;
+            }
+
+            window.getMedicationStepData = function () {
+                if (window.__medicationStepData) {
+                    return window.__medicationStepData;
+                }
+
+                const dataElement = document.getElementById('medication-step-data');
+                let parsed = [];
+
+                if (dataElement) {
+                    const raw = dataElement.textContent ? dataElement.textContent.trim() : '';
+                    if (raw) {
+                        try {
+                            parsed = JSON.parse(raw);
+                        } catch (error) {
+                            console.error('Unable to parse medication configuration data', error);
+                        }
+                    }
+                }
+
+                if (!Array.isArray(parsed) || parsed.length === 0) {
+                    parsed = [{
+                        slug: 'wegovy',
+                        label: 'the weight loss medication',
+                        weight: '',
+                        weight2: '',
+                        unit: 'kg',
+                        dose: '',
+                        recentDose: ''
+                    }];
+                }
+
+                window.__medicationStepData = parsed.map(function (item, index) {
+                    const slug = (item && typeof item.slug === 'string' && item.slug.trim() !== '')
+                        ? item.slug.trim()
+                        : `medication-${index + 1}`;
+
+                    const recentDoseOptions = (item && Array.isArray(item.recentDoseOptions))
+                        ? item.recentDoseOptions.reduce(function (options, option) {
+                            if (!option || typeof option !== 'object') {
+                                return options;
+                            }
+
+                            const hasValue = Object.prototype.hasOwnProperty.call(option, 'value');
+                            const hasLabel = Object.prototype.hasOwnProperty.call(option, 'label');
+
+                            if (!hasValue || !hasLabel) {
+                                return options;
+                            }
+
+                            const value = option.value;
+                            const label = option.label;
+
+                            if ((value === null || value === undefined) || (label === null || label === undefined)) {
+                                return options;
+                            }
+
+                            const valueString = String(value).trim();
+                            const labelString = String(label).trim();
+
+                            if (valueString === '' || labelString === '') {
+                                return options;
+                            }
+
+                            options.push({
+                                value: valueString,
+                                label: labelString,
+                            });
+
+                            return options;
+                        }, [])
+                        : [];
+
+                    return {
+                        slug: slug,
+                        label: (item && typeof item.label === 'string' && item.label.trim() !== '') ? item.label : 'the weight loss medication',
+                        weight: item && typeof item.weight !== 'undefined' && item.weight !== null ? item.weight : '',
+                        weight2: item && typeof item.weight2 !== 'undefined' && item.weight2 !== null ? item.weight2 : '',
+                        unit: item && item.unit === 'st-lbs' ? 'st-lbs' : 'kg',
+                        dose: item && typeof item.dose !== 'undefined' && item.dose !== null ? item.dose : '',
+                        recentDose: item && typeof item.recentDose !== 'undefined' && item.recentDose !== null ? item.recentDose : '',
+                        recentDoseOptions: recentDoseOptions
+                    };
+                });
+
+                return window.__medicationStepData;
+            };
+        })();
+    </script>
  <!--  <a href="/get-started/questionnaire?step=startagain" style="text-decoration: none;color: #000;" >Start again </a>-->
 
     <perch:if id="step" value="howold">
@@ -1137,21 +1232,7 @@
                        </div>
 
                    </div>-->
-                    <h2>What was your weight in kg/st-lbs before starting <span id="medication">the weight loss medication</span>?</h2>
-                    <div class="weight-inputs">
-                        <input type="text" name="weight-wegovy" id="weight-wegovy" placeholder="Kg">
-                        <input type="hidden" id="weight2-wegovy" required name="weight2-wegovy" placeholder="lbs"/>
-                        <input type="hidden" id="unit-wegovy" value="kg"   name="unit-wegovy" >
-
-                        <div class="st_lbs" id="st-lbs-inputs" style="display: none;">
-                            <input type="text" placeholder="St">
-                            <input type="text" placeholder="Lbs">
-                        </div>
-                    </div>
-                    <div class="unit-selector unit_selector">
-                        <label><input type="radio" required onchange="radioweight(this.value)" name="unit-wegovyradio" required value="kg" checked>kg</label>
-                        <label><input type="radio"  onchange="radioweight(this.value)" name="unit-wegovyradio" value="st-lbs"> st/lbs</label>
-                    </div>
+                    <div id="medication-weight-fields"></div>
 
                   <!--  <div class="buttons skip ">
                         <button class="back skip_button "><a href="/get-started/questionnaire?step=dose_wegovy" style="text-decoration: none;color: #000;" >Skip</a></button>
@@ -1164,7 +1245,7 @@
                         <button class="back"><a href='<perch:forms id="previousPage"  />' style="text-decoration: none;color: #000;" >Back</a></button>
                        <!-- <perch:if id="reviewed" value="InProcess" ><button id="reviewButton" style="background-color: rgb(176, 209, 54);" class="btn_next" ><a href='/get-started/review-questionnaire'>Back to Review Page</a></button></perch:if>-->
 
-                        <button onclick="submitForm('weight-wegovy')" class="next"><span  style="text-decoration: none;color: #000;" >Next →</span></button>
+                        <button id="medication-weight-next" onclick="submitForm('weight-wegovy')" class="next"><span  style="text-decoration: none;color: #000;" >Next →</span></button>
                     </div>
                 </div>
 
@@ -1172,34 +1253,83 @@
 
         </section>
         <script>
+            (function () {
+                const container = document.getElementById('medication-weight-fields');
+                const nextButton = document.getElementById('medication-weight-next');
 
-            function radioweight(value) {
-
-                const weight = document.getElementById("weight-wegovy");
-                document.getElementById("unit-wegovy").value = document.querySelector('input[name=unit-wegovyradio]:checked').value;
-
-                if (value === "kg") {
-                    weight.placeholder = "Kg";
-                    document.getElementById("weight2-wegovy").type = "hidden";
-                } else {
-                    document.getElementById("weight2-wegovy").type = "text";
-                    weight.placeholder = "st";
-
+                if (!container) {
+                    return;
                 }
-                /*  const weightkg = document.getElementById("weight");
-                  const weightlbs = document.getElementById("weight-lbs");
 
-                  if (value === "kg") {
-                      weightlbs.style.display = "none";
-                      weightkg.style.display = "flex";
-                  } else {
-                      weightlbs.style.display = "block";
-                      weightkg.style.display = "none";
-                  }*/
+                const escapeHtml = function (value) {
+                    if (value === null || value === undefined) {
+                        return '';
+                    }
 
+                    return String(value)
+                        .replace(/&/g, '&amp;')
+                        .replace(/</g, '&lt;')
+                        .replace(/>/g, '&gt;')
+                        .replace(/"/g, '&quot;')
+                        .replace(/'/g, '&#039;');
+                };
+
+                const medicationWeights = window.getMedicationStepData();
+
+                medicationWeights.forEach(function (config, index) {
+                    const slug = config.slug || `medication-${index + 1}`;
+                    const unit = config.unit === 'st-lbs' ? 'st-lbs' : 'kg';
+                    const placeholder = unit === 'kg' ? 'Kg' : 'St';
+                    const weight2Type = unit === 'st-lbs' ? 'text' : 'hidden';
+                    const label = config.label || 'the weight loss medication';
+
+                    const fieldHtml = `
+                        <div class="medication-weight" data-medication="${escapeHtml(label)}">
+                            <h2>What was your weight in kg/st-lbs before starting <span class="medication-name">${escapeHtml(label)}</span>?</h2>
+                            <div class="weight-inputs">
+                                <input type="text" name="weight-${slug}" id="weight-${slug}" placeholder="${placeholder}" value="${escapeHtml(config.weight)}">
+                                <input type="${weight2Type}" id="weight2-${slug}" name="weight2-${slug}" placeholder="lbs" value="${escapeHtml(config.weight2)}" />
+                                <input type="hidden" id="unit-${slug}" value="${unit}" name="unit-${slug}">
+                                <div class="st_lbs" id="st-lbs-inputs-${slug}" style="display: none;">
+                                    <input type="text" placeholder="St">
+                                    <input type="text" placeholder="Lbs">
+                                </div>
+                            </div>
+                            <div class="unit-selector unit_selector">
+                                <label><input type="radio" onchange="radioweightMedication(this.value, '${slug}')" name="unit-${slug}radio" value="kg" ${unit === 'kg' ? 'checked' : ''}>kg</label>
+                                <label><input type="radio" onchange="radioweightMedication(this.value, '${slug}')" name="unit-${slug}radio" value="st-lbs" ${unit === 'st-lbs' ? 'checked' : ''}> st/lbs</label>
+                            </div>
+                        </div>
+                    `;
+
+                    container.insertAdjacentHTML('beforeend', fieldHtml);
+
+                    if (index === 0 && nextButton) {
+                        nextButton.setAttribute('onclick', `submitForm('weight-${slug}')`);
+                    }
+                });
+            })();
+
+            function radioweightMedication(value, slug) {
+                const weight = document.getElementById(`weight-${slug}`);
+                const weight2 = document.getElementById(`weight2-${slug}`);
+                const unitInput = document.getElementById(`unit-${slug}`);
+
+                if (!weight || !weight2 || !unitInput) {
+                    return;
+                }
+
+                unitInput.value = value;
+
+                if (value === 'kg') {
+                    weight.placeholder = 'Kg';
+                    weight2.type = 'hidden';
+                } else {
+                    weight.placeholder = 'St';
+                    weight2.type = 'text';
+                    weight2.placeholder = 'lbs';
+                }
             }
-
-
         </script>
     </perch:if>
     <perch:if id="step" value="dose_wegovy" >
@@ -1219,43 +1349,14 @@
 
                     </div>-->
 
+                    <div id="medication-dose-fields"></div>
 
-                    <div class="old_title">
-                        <h2>When was your last dose of <span id="medication">the weight loss medication</span>?</h2>
-                    </div>
-
-
-
-                    <div class="under">
-
-
-                        <input type="radio" value="less4" onclick="submitForm('dose-wegovy')" name="dose-wegovy"  required id="Under" checked="checked">
-                        <label for="Under" id="Less">Less than 4 weeks ago</label>
-
-                        <input type="radio" value="4to6"  onclick="submitForm('dose-wegovy')" name="dose-wegovy"  id="4to6">
-                        <label for="4to6" id="ago">4-6 weeks ago</label>
-
-                        <input type="radio" value="over6" onclick="submitForm('dose-wegovy')" name="dose-wegovy"  id="over">
-                        <label for="over" id="More">More than 6 weeks ago</label>
-
+                    <div class="buttons">
                         <input type="hidden" id="nextstep" name="nextstep" value="recently_wegovy">
 
-                    </div>
+                        <button class="back"><a href='<perch:forms id="previousPage"  />'>Back</a></button>
 
-
-
-
-
-
-
-                    <div class="get_started">
-                        <div class="started_button">
-                            <div class="get_btn">
-                                <button><a href='<perch:forms id="previousPage"  />'>Back</a></button>
-                               <!-- <perch:if id="reviewed" value="InProcess" ><button id="reviewButton" style="background-color: rgb(176, 209, 54);" class="btn_next" ><a href='/get-started/review-questionnaire'>Back to Review Page</a></button></perch:if>-->
-
-                            </div>
-                        </div>
+                        <button id="medication-dose-next" class="next" onclick="submitForm('dose-wegovy')"><span style="text-decoration: none;color: #000;" >Next →</span></button>
                     </div>
 
                 </div>
@@ -1265,6 +1366,72 @@
 
 
         </section>
+        <script>
+            (function () {
+                const container = document.getElementById('medication-dose-fields');
+                const nextButton = document.getElementById('medication-dose-next');
+
+                if (!container) {
+                    return;
+                }
+
+                const escapeHtml = function (value) {
+                    if (value === null || value === undefined) {
+                        return '';
+                    }
+
+                    return String(value)
+                        .replace(/&/g, '&amp;')
+                        .replace(/</g, '&lt;')
+                        .replace(/>/g, '&gt;')
+                        .replace(/"/g, '&quot;')
+                        .replace(/'/g, '&#039;');
+                };
+
+                const options = [
+                    { value: 'less4', label: 'Less than 4 weeks ago' },
+                    { value: '4to6', label: '4-6 weeks ago' },
+                    { value: 'over6', label: 'More than 6 weeks ago' }
+                ];
+
+                const medicationConfigs = window.getMedicationStepData();
+
+                medicationConfigs.forEach(function (config, index) {
+                    const slug = config.slug || `medication-${index + 1}`;
+                    const label = config.label || 'the weight loss medication';
+                    const hasExistingValue = typeof config.dose === 'string' && config.dose !== '';
+
+                    let fieldHtml = `
+                        <div class="medication-dose" data-medication="${escapeHtml(label)}">
+                            <div class="old_title">
+                                <h2>When was your last dose of <span class="medication-name">${escapeHtml(label)}</span>?</h2>
+                            </div>
+                            <div class="under">
+                    `;
+
+                    options.forEach(function (option, optionIndex) {
+                        const isChecked = hasExistingValue ? config.dose === option.value : optionIndex === 0;
+                        const requiredAttr = optionIndex === 0 ? ' required' : '';
+                        const inputId = `dose-${slug}-${option.value}`;
+                        fieldHtml += `
+                                <input type="radio" value="${option.value}" id="${inputId}" name="dose-${slug}"${requiredAttr}${isChecked ? ' checked' : ''}>
+                                <label for="${inputId}">${escapeHtml(option.label)}</label>
+                        `;
+                    });
+
+                    fieldHtml += `
+                            </div>
+                        </div>
+                    `;
+
+                    container.insertAdjacentHTML('beforeend', fieldHtml);
+
+                    if (index === 0 && nextButton) {
+                        nextButton.setAttribute('onclick', `submitForm('dose-${slug}')`);
+                    }
+                });
+            })();
+        </script>
     </perch:if>
     <perch:if id="step" value="recently_wegovy" >
         <section class="how_old">
@@ -1276,51 +1443,120 @@
                      </div>
 
                  </div>-->
-                    <div class="old_title">
-                        <h2>What dose of <span id="medication">the weight loss medication</span> were you prescribed most recently?</h2><br>
+                    <div id="medication-recent-dose-fields"></div>
 
-
-                    </div>
-                    <div class="under">
-                        <input type="radio" value="25mg" onclick="submitForm('recently-dose-wegovy')" name="recently-dose-wegovy"  required id="25mg" checked="checked">
-                        <label for="25mg" >0.25mg/2.5mg</label>
-
-
-                        <input type="radio" id="05mg"  value="05mg" onclick="submitForm('recently-dose-wegovy')" name="recently-dose-wegovy" >
-                        <label for="05mg" >0.5mg/5mg</label>
-
-
-                        <input type="radio" id="1mg"  value="1mg"  onclick="submitForm('recently-dose-wegovy')" name="recently-dose-wegovy">
-                        <label for="1mg" >1mg/7.5mg</label>
-
-                        <input type="radio" id="17mg" value="17mg" onclick="submitForm('recently-dose-wegovy')" name="recently-dose-wegovy">
-                        <label for="17mg" >1.7mg/12.5mg</label>
-
-
-                        <input type="radio" value="24mg" id="24mg" onclick="submitForm('recently-dose-wegovy')" name="recently-dose-wegovy">
-                        <label for="24mg" >2.4mg/15mg</label>
-
-                        <input type="radio" value="other" id="other" onclick="submitForm('recently-dose-wegovy')" name="recently-dose-wegovy">
-                        <label for="other" >Other</label>
-
+                    <div class="buttons">
                         <input type="hidden" id="nextstep" name="nextstep" value="continue_with_wegovy">
 
+                        <button class="back"><a href='<perch:forms id="previousPage"  />'>Back</a></button>
 
-                    </div>
-
-                    <div class="get_started">
-                        <div class="started_button">
-                            <div class="get_btn">
-                                <button><a href='<perch:forms id="previousPage"  />'>Back</a></button>
-                               <!-- <perch:if id="reviewed" value="InProcess" ><button id="reviewButton" style="background-color: rgb(176, 209, 54);" class="btn_next" ><a href='/get-started/review-questionnaire'>Back to Review Page</a></button></perch:if>-->
-
-                            </div>
-                        </div>
+                        <button id="medication-recent-dose-next" class="next" onclick="submitForm('recently-dose-wegovy')"><span style="text-decoration: none;color: #000;" >Next →</span></button>
                     </div>
 
                 </div>
             </div>
         </section>
+        <script>
+            (function () {
+                const container = document.getElementById('medication-recent-dose-fields');
+                const nextButton = document.getElementById('medication-recent-dose-next');
+
+                if (!container) {
+                    return;
+                }
+
+                const escapeHtml = function (value) {
+                    if (value === null || value === undefined) {
+                        return '';
+                    }
+
+                    return String(value)
+                        .replace(/&/g, '&amp;')
+                        .replace(/</g, '&lt;')
+                        .replace(/>/g, '&gt;')
+                        .replace(/"/g, '&quot;')
+                        .replace(/'/g, '&#039;');
+                };
+
+                const normalizeValue = function (value) {
+                    if (value === null || value === undefined) {
+                        return '';
+                    }
+
+                    return String(value).trim().toLowerCase();
+                };
+
+                const toIdSuffix = function (value, fallbackIndex) {
+                    const normalized = normalizeValue(value)
+                        .replace(/[^a-z0-9]+/g, '-')
+                        .replace(/^-+|-+$/g, '');
+
+                    if (normalized !== '') {
+                        return normalized;
+                    }
+
+                    return String(fallbackIndex);
+                };
+
+                const medicationConfigs = window.getMedicationStepData();
+
+                medicationConfigs.forEach(function (config, index) {
+                    const slug = config.slug || `medication-${index + 1}`;
+                    const label = config.label || 'the weight loss medication';
+                    const storedRecentDose = typeof config.recentDose === 'string' ? config.recentDose : '';
+                    const recentDoseOptions = Array.isArray(config.recentDoseOptions) ? config.recentDoseOptions : [];
+                    const hasRadioOptions = recentDoseOptions.length > 0;
+
+                    let fieldHtml = `
+                        <div class="medication-recent-dose" data-medication="${escapeHtml(label)}">
+                            <div class="old_title">
+                                <h2>What dose of <span class="medication-name">${escapeHtml(label)}</span> were you prescribed most recently?</h2>
+                            </div>
+                            <div class="under">
+                    `;
+
+                    if (hasRadioOptions) {
+                        const normalizedStoredValue = normalizeValue(storedRecentDose);
+
+                        recentDoseOptions.forEach(function (option, optionIndex) {
+                            if (!option || typeof option.value === 'undefined' || typeof option.label === 'undefined') {
+                                return;
+                            }
+
+                            const optionValue = option.value;
+                            const optionLabel = option.label;
+                            const normalizedOptionValue = normalizeValue(optionValue);
+                            const isChecked = normalizedStoredValue !== ''
+                                ? normalizedStoredValue === normalizedOptionValue
+                                : optionIndex === 0;
+                            const requiredAttr = optionIndex === 0 ? ' required' : '';
+                            const inputId = `recently-dose-${slug}-${toIdSuffix(optionValue, optionIndex)}`;
+
+                            fieldHtml += `
+                                <input type="radio" value="${escapeHtml(optionValue)}" id="${escapeHtml(inputId)}" name="recently-dose-${slug}"${requiredAttr}${isChecked ? ' checked' : ''}>
+                                <label for="${escapeHtml(inputId)}">${escapeHtml(optionLabel)}</label>
+                            `;
+                        });
+                    } else {
+                        const inputId = `recently-dose-${slug}`;
+                        fieldHtml += `
+                                <input type="text" id="${escapeHtml(inputId)}" name="recently-dose-${slug}" value="${escapeHtml(storedRecentDose)}" required placeholder="Enter your most recent dose">
+                        `;
+                    }
+
+                    fieldHtml += `
+                            </div>
+                        </div>
+                    `;
+
+                    container.insertAdjacentHTML('beforeend', fieldHtml);
+
+                    if (index === 0 && nextButton) {
+                        nextButton.setAttribute('onclick', `submitForm('recently-dose-${slug}')`);
+                    }
+                });
+            })();
+        </script>
 
     </perch:if>
     <perch:if id="step" value="continue_with_wegovy">

--- a/perch/templates/pages/getStarted/questionnaire.php
+++ b/perch/templates/pages/getStarted/questionnaire.php
@@ -1,6 +1,8 @@
 <?php
 if (session_status() === PHP_SESSION_NONE) session_start();
 
+require_once dirname(__DIR__, 3) . '/addons/apps/perch_members/questionnaire_medication_helpers.php';
+
 /*
 function generateUUID() {
     return sprintf(
@@ -359,8 +361,68 @@ $back_link = $back_links[$_GET["step"]] ?? '/get-started';
 
 PerchSystem::set_var('previousPage', $back_link);
 PerchSystem::set_var('answers', $_SESSION['questionnaire']);
- PerchSystem::set_vars($_SESSION['questionnaire']);
- perch_form('questionnaire.html');
+PerchSystem::set_vars($_SESSION['questionnaire']);
+
+$selectedMedications = [];
+if (!empty($_SESSION['questionnaire']['medications']) && is_array($_SESSION['questionnaire']['medications'])) {
+    foreach ($_SESSION['questionnaire']['medications'] as $medication) {
+        $slug = perch_questionnaire_medication_slug((string) $medication);
+        if ($slug === '' || $slug === 'none') {
+            continue;
+        }
+
+        $recentDoseOptionsConfig = perch_questionnaire_recent_dose_options($slug);
+        $recentDoseOptions = [];
+        if (is_array($recentDoseOptionsConfig)) {
+            foreach ($recentDoseOptionsConfig as $value => $displayLabel) {
+                $recentDoseOptions[] = [
+                    'value' => $value,
+                    'label' => $displayLabel,
+                ];
+            }
+        }
+
+        $selectedMedications[$slug] = [
+            'slug' => $slug,
+            'label' => perch_questionnaire_medication_label($slug),
+            'weight' => $_SESSION['questionnaire']["weight-{$slug}"] ?? '',
+            'weight2' => $_SESSION['questionnaire']["weight2-{$slug}"] ?? '',
+            'unit' => $_SESSION['questionnaire']["unit-{$slug}"] ?? 'kg',
+            'dose' => $_SESSION['questionnaire']["dose-{$slug}"] ?? '',
+            'recentDose' => $_SESSION['questionnaire']["recently-dose-{$slug}"] ?? '',
+            'recentDoseOptions' => $recentDoseOptions,
+        ];
+    }
+}
+
+if (empty($selectedMedications)) {
+    $defaultSlug = 'wegovy';
+    $recentDoseOptionsConfig = perch_questionnaire_recent_dose_options($defaultSlug);
+    $recentDoseOptions = [];
+    if (is_array($recentDoseOptionsConfig)) {
+        foreach ($recentDoseOptionsConfig as $value => $displayLabel) {
+            $recentDoseOptions[] = [
+                'value' => $value,
+                'label' => $displayLabel,
+            ];
+        }
+    }
+    $selectedMedications[$defaultSlug] = [
+        'slug' => $defaultSlug,
+        'label' => perch_questionnaire_medication_label($defaultSlug),
+        'weight' => $_SESSION['questionnaire']['weight-wegovy'] ?? '',
+        'weight2' => $_SESSION['questionnaire']['weight2-wegovy'] ?? '',
+        'unit' => $_SESSION['questionnaire']['unit-wegovy'] ?? 'kg',
+        'dose' => $_SESSION['questionnaire']['dose-wegovy'] ?? '',
+        'recentDose' => $_SESSION['questionnaire']['recently-dose-wegovy'] ?? '',
+        'recentDoseOptions' => $recentDoseOptions,
+    ];
+}
+
+$medicationWeightJson = json_encode(array_values($selectedMedications), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
+PerchSystem::set_var('medication_weight_json', $medicationWeightJson ?: '[]');
+
+perch_form('questionnaire.html');
 ?>
 
 


### PR DESCRIPTION
## Summary
- centralize recent dose option lookup so Wegovy/Mounjaro keep shared presets while Ozempic uses 0.25–2 mg choices
- expose medication-specific recent dose options in the questionnaire payload and render radios or a free-text field per selection on the front end
- map stored recent dose answers back to their friendly labels when reviewing responses

## Testing
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
- php -l perch/addons/apps/perch_members/questionnaire_medication_helpers.php
- php -l perch/templates/pages/getStarted/questionnaire.php
- php -l perch/templates/pages/getStarted/review-questionnaire.php

------
https://chatgpt.com/codex/tasks/task_b_68d3be2bd8b883249d00b6e9b885369b