### PR TITLE
Update Wegovy and Mounjaro dose options

### DIFF
--- a/perch/addons/apps/perch_members/questionnaire_medication_helpers.php
+++ b/perch/addons/apps/perch_members/questionnaire_medication_helpers.php
@@ -45,15 +45,6 @@ if (!function_exists('perch_questionnaire_recent_dose_options')) {
     {
         $slug = perch_questionnaire_medication_slug($slug);
 
-        $defaultOptions = [
-            '25mg' => '0.25mg/2.5mg',
-            '05mg' => '0.5mg/5mg',
-            '1mg'  => '1mg/7.5mg',
-            '17mg' => '1.7mg/12.5mg',
-            '24mg' => '2.4mg/15mg',
-            'other' => 'Other',
-        ];
-
         if ($slug === 'ozempic') {
             return [
                 '0.25 mg' => '0.25 mg',
@@ -63,8 +54,28 @@ if (!function_exists('perch_questionnaire_recent_dose_options')) {
             ];
         }
 
-        if ($slug === 'wegovy' || $slug === 'mounjaro') {
-            return $defaultOptions;
+        if ($slug === 'wegovy') {
+            return [
+                '0.25mg' => '0.25mg',
+                '0.5mg' => '0.5mg',
+                '0.75mg' => '0.75mg',
+                '1.0mg' => '1.0mg',
+                '1.7mg' => '1.7mg',
+                '2.4mg' => '2.4mg',
+                'other' => 'Other',
+            ];
+        }
+
+        if ($slug === 'mounjaro') {
+            return [
+                '2.5mg' => '2.5mg',
+                '5.0mg' => '5.0mg',
+                '7.5mg' => '7.5mg',
+                '10mg' => '10mg',
+                '12.5mg' => '12.5mg',
+                '15mg' => '15mg',
+                'other' => 'Other',
+            ];
         }
 
         return null;


### PR DESCRIPTION
## Summary
- update Wegovy questionnaire recent dose options to list individual strengths from 0.25mg through 2.4mg
- update Mounjaro questionnaire recent dose options to list strengths from 2.5mg through 15mg
- retain an "Other" fallback option for both medications

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d52038ae248324be89cf3e8d3a9d7b