### PR TITLE
Display continue dose options per selected medication

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
@@ -20,21 +20,31 @@ class PerchMembers_Questionnaires extends PerchAPI_Factory
                 'over6' => 'More than 6 weeks ago',
             ];
 
+            $continueDoseOptions = [
+                'increase' => 'Increase my dose',
+                'keep' => 'Keep my dose',
+                'decrease' => 'Decrease my dose',
+                'not-continue' => "I don't want to continue with this medication",
+            ];
+
             foreach ($this->getMedicationSlugs() as $slug) {
                 $label = $this->getMedicationLabel($slug);
                 $weightLabel = 'What was your weight in kg/st-lbs before starting ' . $label . '?';
                 $lastDoseLabel = 'When was your last dose of ' . $label . '?';
                 $recentDoseLabel = 'What dose of ' . $label . ' were you prescribed most recently?';
+                $continueDoseLabel = 'If you want to continue with ' . $label . ', what dose would you like to continue with?';
 
                 $this->steps["weight-{$slug}"] = 'starting_wegovy';
                 $this->steps["unit-{$slug}"] = 'starting_wegovy';
                 $this->steps["weight2-{$slug}"] = 'starting_wegovy';
                 $this->steps["dose-{$slug}"] = 'dose_wegovy';
                 $this->steps["recently-dose-{$slug}"] = 'recently_wegovy';
+                $this->steps["continue-dose-{$slug}"] = 'continue_with_wegovy';
 
                 $this->questions["weight-{$slug}"] = $weightLabel;
                 $this->questions["dose-{$slug}"] = $lastDoseLabel;
                 $this->questions["recently-dose-{$slug}"] = $recentDoseLabel;
+                $this->questions["continue-dose-{$slug}"] = $continueDoseLabel;
 
                 $this->questions_and_answers["weight-{$slug}"] = [
                     'label' => $weightLabel,
@@ -63,6 +73,13 @@ class PerchMembers_Questionnaires extends PerchAPI_Factory
                 }
 
                 $this->questions_and_answers["recently-dose-{$slug}"] = $recentDoseField;
+
+                $this->questions_and_answers["continue-dose-{$slug}"] = [
+                    'label' => $continueDoseLabel,
+                    'type' => 'radio',
+                    'name' => "continue-dose-{$slug}",
+                    'options' => $continueDoseOptions,
+                ];
             }
 
             $this->ensureQuestionOrderColumnExists();
@@ -982,13 +999,14 @@ function getNextStepforFirstOrder(array $data): string {
               if (empty($data[$recentDoseKey])) {
                   $errors[] = 'Please provide the most recent dose prescribed for ' . $label . '.';
               }
+
+              $continueDoseKey = "continue-dose-{$medicationSlug}";
+              if (array_key_exists($continueDoseKey, $data) && empty($data[$continueDoseKey])) {
+                  $errors[] = 'Please select how you would like to continue with ' . $label . '.';
+              }
           }
 
           if (in_array('wegovy', $selectedMedicationSlugs, true)) {
-              if (empty($data['continue-dose-wegovy'])) {
-                  $errors[] = 'Please select your preferred continuation dose.';
-              }
-
               if (empty($data['effects_with_wegovy'])) {
                   $errors[] = 'Please indicate if you’ve had any side effects.';
               }

--- a/perch/addons/apps/perch_members/questionnaire_default_questions.php
+++ b/perch/addons/apps/perch_members/questionnaire_default_questions.php
@@ -460,7 +460,7 @@ return [
                 'increase' => 'Increase my dose',
                 'keep' => 'Keep my dose',
                 'decrease' => 'Decrease my dose',
-                'stop' => 'I don\'t want to continue with this medication',
+                'not-continue' => 'I don\'t want to continue with this medication',
             ],
             'step' => 'continue_with_wegovy',
         ],

--- a/perch/templates/forms/questionnaire.html
+++ b/perch/templates/forms/questionnaire.html
@@ -33,7 +33,8 @@
                         weight2: '',
                         unit: 'kg',
                         dose: '',
-                        recentDose: ''
+                        recentDose: '',
+                        continueDose: ''
                     }];
                 }
 
@@ -86,6 +87,7 @@
                         unit: item && item.unit === 'st-lbs' ? 'st-lbs' : 'kg',
                         dose: item && typeof item.dose !== 'undefined' && item.dose !== null ? item.dose : '',
                         recentDose: item && typeof item.recentDose !== 'undefined' && item.recentDose !== null ? item.recentDose : '',
+                        continueDose: item && typeof item.continueDose !== 'undefined' && item.continueDose !== null ? item.continueDose : '',
                         recentDoseOptions: recentDoseOptions
                     };
                 });
@@ -268,6 +270,7 @@
                 </form>
             </div>
         </section>
+        
     </perch:if>
     <perch:if id="step" value="ethnicity,asian,Black (African/Caribbean),White" match="within" >
 
@@ -745,6 +748,94 @@
                 </div>
             </div>
         </section>
+        <script>
+            (function () {
+                const container = document.getElementById('medication-continue-dose-fields');
+
+                if (!container) {
+                    return;
+                }
+
+                const escapeHtml = function (value) {
+                    if (value === null || value === undefined) {
+                        return '';
+                    }
+
+                    return String(value)
+                        .replace(/&/g, '&amp;')
+                        .replace(/</g, '&lt;')
+                        .replace(/>/g, '&gt;')
+                        .replace(/"/g, '&quot;')
+                        .replace(/'/g, '&#039;');
+                };
+
+                const normalizeValue = function (value) {
+                    if (value === null || value === undefined) {
+                        return '';
+                    }
+
+                    return String(value).trim().toLowerCase();
+                };
+
+                const toIdSuffix = function (value, fallbackIndex) {
+                    const normalized = normalizeValue(value)
+                        .replace(/[^a-z0-9]+/g, '-')
+                        .replace(/^-+|-+$/g, '');
+
+                    if (normalized !== '') {
+                        return normalized;
+                    }
+
+                    return String(fallbackIndex);
+                };
+
+                const medicationConfigs = window.getMedicationStepData();
+                const options = [
+                    { value: 'increase', label: 'Increase my dose' },
+                    { value: 'keep', label: 'Keep my dose' },
+                    { value: 'decrease', label: 'Decrease my dose' },
+                    { value: 'not-continue', label: "I don't want to continue with this medication" }
+                ];
+
+                medicationConfigs.forEach(function (config, index) {
+                    const slug = config.slug || `medication-${index + 1}`;
+                    const label = config.label || 'the weight loss medication';
+                    const storedValue = typeof config.continueDose === 'string' ? config.continueDose : '';
+                    const normalizedStoredValue = normalizeValue(storedValue);
+
+                    let fieldHtml = `
+                        <div class="medication-continue-dose" data-medication="${escapeHtml(label)}">
+                            <div class="old_title">
+                                <h3 class="medication-subtitle">${escapeHtml(label)}</h3>
+                            </div>
+                            <div class="under">
+                    `;
+
+                    options.forEach(function (option, optionIndex) {
+                        const optionValue = option.value;
+                        const optionLabel = option.label;
+                        const normalizedOptionValue = normalizeValue(optionValue);
+                        const isChecked = normalizedStoredValue !== ''
+                            ? normalizedStoredValue === normalizedOptionValue
+                            : optionIndex === 0;
+                        const requiredAttr = optionIndex === 0 ? ' required' : '';
+                        const inputId = `continue-dose-${slug}-${toIdSuffix(optionValue, optionIndex)}`;
+
+                        fieldHtml += `
+                                <input type="radio" value="${escapeHtml(optionValue)}" id="${escapeHtml(inputId)}" name="continue-dose-${escapeHtml(slug)}"${requiredAttr}${isChecked ? ' checked' : ''} onclick="submitForm('continue-dose-${slug}')">
+                                <label for="${escapeHtml(inputId)}">${escapeHtml(optionLabel)}</label>
+                        `;
+                    });
+
+                    fieldHtml += `
+                            </div>
+                        </div>
+                    `;
+
+                    container.insertAdjacentHTML('beforeend', fieldHtml);
+                });
+            })();
+        </script>
     </perch:if>
 
 
@@ -1581,26 +1672,8 @@
 
                     </div>
                     <div class="under">
-                        <input type="radio" id="increase" value="increase" required onclick="submitForm('continue-dose-wegovy')" name="continue-dose-wegovy"  checked="checked">
-                        <label for="increase" >Increase my dose</label>
-
-
-                        <input type="radio" id="keep" value="keep"  onclick="submitForm('continue-dose-wegovy')" name="continue-dose-wegovy" >
-                        <label for="keep" >Keep my dose </label>
-
-
-                        <input type="radio"  id="decrease"  value="decrease"  onclick="submitForm('continue-dose-wegovy')" name="continue-dose-wegovy">
-                        <label for="decrease" id="dose">Decrease my dose</label>
-
-                        <input type="radio" id="not-continue"  value="not-continue"  onclick="submitForm('continue-dose-wegovy')" name="continue-dose-wegovy">
-                        <label for="not-continue" >I don't want to continue with this medication</label>
+                        <div id="medication-continue-dose-fields"></div>
                         <input type="hidden" id="nextstep" name="nextstep" value="effects_with_wegovy">
-
-
-
-
-
-
                     </div>
 
                     <div class="get_started">
@@ -1616,6 +1689,94 @@
                 </div>
             </div>
         </section>
+        <script>
+            (function () {
+                const container = document.getElementById('medication-continue-dose-fields');
+
+                if (!container) {
+                    return;
+                }
+
+                const escapeHtml = function (value) {
+                    if (value === null || value === undefined) {
+                        return '';
+                    }
+
+                    return String(value)
+                        .replace(/&/g, '&amp;')
+                        .replace(/</g, '&lt;')
+                        .replace(/>/g, '&gt;')
+                        .replace(/"/g, '&quot;')
+                        .replace(/'/g, '&#039;');
+                };
+
+                const normalizeValue = function (value) {
+                    if (value === null || value === undefined) {
+                        return '';
+                    }
+
+                    return String(value).trim().toLowerCase();
+                };
+
+                const toIdSuffix = function (value, fallbackIndex) {
+                    const normalized = normalizeValue(value)
+                        .replace(/[^a-z0-9]+/g, '-')
+                        .replace(/^-+|-+$/g, '');
+
+                    if (normalized !== '') {
+                        return normalized;
+                    }
+
+                    return String(fallbackIndex);
+                };
+
+                const medicationConfigs = window.getMedicationStepData();
+                const options = [
+                    { value: 'increase', label: 'Increase my dose' },
+                    { value: 'keep', label: 'Keep my dose' },
+                    { value: 'decrease', label: 'Decrease my dose' },
+                    { value: 'not-continue', label: "I don't want to continue with this medication" }
+                ];
+
+                medicationConfigs.forEach(function (config, index) {
+                    const slug = config.slug || `medication-${index + 1}`;
+                    const label = config.label || 'the weight loss medication';
+                    const storedValue = typeof config.continueDose === 'string' ? config.continueDose : '';
+                    const normalizedStoredValue = normalizeValue(storedValue);
+
+                    let fieldHtml = `
+                        <div class="medication-continue-dose" data-medication="${escapeHtml(label)}">
+                            <div class="old_title">
+                                <h3 class="medication-subtitle">${escapeHtml(label)}</h3>
+                            </div>
+                            <div class="under">
+                    `;
+
+                    options.forEach(function (option, optionIndex) {
+                        const optionValue = option.value;
+                        const optionLabel = option.label;
+                        const normalizedOptionValue = normalizeValue(optionValue);
+                        const isChecked = normalizedStoredValue !== ''
+                            ? normalizedStoredValue === normalizedOptionValue
+                            : optionIndex === 0;
+                        const requiredAttr = optionIndex === 0 ? ' required' : '';
+                        const inputId = `continue-dose-${slug}-${toIdSuffix(optionValue, optionIndex)}`;
+
+                        fieldHtml += `
+                                <input type="radio" value="${escapeHtml(optionValue)}" id="${escapeHtml(inputId)}" name="continue-dose-${escapeHtml(slug)}"${requiredAttr}${isChecked ? ' checked' : ''} onclick="submitForm('continue-dose-${slug}')">
+                                <label for="${escapeHtml(inputId)}">${escapeHtml(optionLabel)}</label>
+                        `;
+                    });
+
+                    fieldHtml += `
+                            </div>
+                        </div>
+                    `;
+
+                    container.insertAdjacentHTML('beforeend', fieldHtml);
+                });
+            })();
+        </script>
     </perch:if>
     <perch:if id="step" value="effects_with_wegovy">
         <section class="how_old">

--- a/perch/templates/pages/getStarted/questionnaire.php
+++ b/perch/templates/pages/getStarted/questionnaire.php
@@ -390,6 +390,7 @@ if (!empty($_SESSION['questionnaire']['medications']) && is_array($_SESSION['que
             'unit' => $_SESSION['questionnaire']["unit-{$slug}"] ?? 'kg',
             'dose' => $_SESSION['questionnaire']["dose-{$slug}"] ?? '',
             'recentDose' => $_SESSION['questionnaire']["recently-dose-{$slug}"] ?? '',
+            'continueDose' => $_SESSION['questionnaire']["continue-dose-{$slug}"] ?? '',
             'recentDoseOptions' => $recentDoseOptions,
         ];
     }
@@ -415,6 +416,7 @@ if (empty($selectedMedications)) {
         'unit' => $_SESSION['questionnaire']['unit-wegovy'] ?? 'kg',
         'dose' => $_SESSION['questionnaire']['dose-wegovy'] ?? '',
         'recentDose' => $_SESSION['questionnaire']['recently-dose-wegovy'] ?? '',
+        'continueDose' => $_SESSION['questionnaire']['continue-dose-wegovy'] ?? '',
         'recentDoseOptions' => $recentDoseOptions,
     ];
 }


### PR DESCRIPTION
## Summary
- render the continue dose step dynamically so each selected medication has its own set of options
- include stored continue-dose answers in the questionnaire session data passed to the front end
- register and validate dynamic continue-dose fields for every medication in the questionnaire backend configuration

## Testing
- php -l perch/templates/pages/getStarted/questionnaire.php
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
- php -l perch/addons/apps/perch_members/questionnaire_default_questions.php

------
https://chatgpt.com/codex/tasks/task_b_68d5229467a083249eff38eb2614c9c9