### PR TITLE
Allow editing BMI values in member admin

### DIFF
--- a/perch/addons/apps/perch_members/modes/members.edit.post.php
+++ b/perch/addons/apps/perch_members/modes/members.edit.post.php
@@ -233,7 +233,11 @@ echo '<span id="result-select'.PerchUtil::html($Document->documentID()).'" class
                             echo '<tr>';
                             echo '<td class="action">'.PerchUtil::html($question_label).'</td>';
                             echo '<td>';
-                            echo PerchUtil::html($Questionnaire->answer_text());
+                            if ($slug === 'bmi') {
+                                echo $Form->text('questionnaire_bmi['.$Questionnaire->id().']', $Questionnaire->answer_text(), 'input-simple', false, 'number', 'step="0.1" min="0"');
+                            } else {
+                                echo PerchUtil::html($Questionnaire->answer_text());
+                            }
                             echo '</td>';
                             echo '</tr>';
                         }
@@ -293,7 +297,11 @@ echo '<span id="result-select'.PerchUtil::html($Document->documentID()).'" class
                             echo '<tr>';
                             echo '<td class="action">'.PerchUtil::html($question_label).'</td>';
                             echo '<td>';
-                            echo PerchUtil::html($Questionnaire->answer_text());
+                            if ($slug === 'bmi') {
+                                echo $Form->text('questionnaire_bmi['.$Questionnaire->id().']', $Questionnaire->answer_text(), 'input-simple', false, 'number', 'step="0.1" min="0"');
+                            } else {
+                                echo PerchUtil::html($Questionnaire->answer_text());
+                            }
                             echo '</td>';
                             echo '</tr>';
                         }

--- a/perch/addons/apps/perch_members/modes/members.edit.pre.php
+++ b/perch/addons/apps/perch_members/modes/members.edit.pre.php
@@ -108,6 +108,41 @@
 
         // Tags
         if ($result) {
+            if (is_object($Member) && isset($post['questionnaire_bmi']) && is_array($post['questionnaire_bmi'])) {
+                foreach ($post['questionnaire_bmi'] as $questionnaireID => $bmiValue) {
+                    $questionnaireID = (int) $questionnaireID;
+                    if ($questionnaireID <= 0) {
+                        continue;
+                    }
+
+                    $bmiValue = trim((string) $bmiValue);
+
+                    $QuestionnaireEntry = $Questionnaires->find($questionnaireID);
+                    if (!$QuestionnaireEntry) {
+                        continue;
+                    }
+
+                    if ((int) $QuestionnaireEntry->member_id() !== (int) $Member->id()) {
+                        continue;
+                    }
+
+                    $currentValue = trim((string) $QuestionnaireEntry->answer_text());
+                    if ($currentValue === $bmiValue) {
+                        continue;
+                    }
+
+                    $updateData = [
+                        'answer_text' => $bmiValue,
+                    ];
+
+                    $entryDetails = $QuestionnaireEntry->to_array();
+                    if (is_array($entryDetails) && array_key_exists('answer', $entryDetails)) {
+                        $updateData['answer'] = $bmiValue;
+                    }
+
+                    $QuestionnaireEntry->update($updateData);
+                }
+            }
 
             // existing tags
             $Tags->remove_from_member($Member->id(), $existing_tagIDs);


### PR DESCRIPTION
## Summary
- render BMI questionnaire answers in the member admin as editable numeric inputs for both initial and reorder questionnaires
- persist posted BMI overrides by updating the related questionnaire records when saving a member

## Testing
- php -l perch/addons/apps/perch_members/modes/members.edit.post.php
- php -l perch/addons/apps/perch_members/modes/members.edit.pre.php

------
https://chatgpt.com/codex/tasks/task_b_68d53ad6e7b483248b94c48a9de491f4