### PR TITLE
Show BMI value with edit toggle in admin

### DIFF
--- a/perch/addons/apps/perch_members/modes/members.edit.post.php
+++ b/perch/addons/apps/perch_members/modes/members.edit.post.php
@@ -208,6 +208,7 @@ echo '<span id="result-select'.PerchUtil::html($Document->documentID()).'" class
              <?php
 
              $questions=$Questionnaires->get_questions();
+             $bmi_edit_controls_needed = false;
 
                 if (PerchUtil::count($questionnaire)) {
                     $answers_by_slug = [];
@@ -233,7 +234,32 @@ echo '<span id="result-select'.PerchUtil::html($Document->documentID()).'" class
                             echo '<tr>';
                             echo '<td class="action">'.PerchUtil::html($question_label).'</td>';
                             echo '<td>';
-                            echo PerchUtil::html($Questionnaire->answer_text());
+                            if ($slug === 'bmi') {
+                                $bmiValue = $Questionnaire->answer_text();
+                                if ($bmiValue === null || $bmiValue === '') {
+                                    $entryDetails = $Questionnaire->to_array();
+                                    if (is_array($entryDetails) && isset($entryDetails['answer']) && $entryDetails['answer'] !== '') {
+                                        $bmiValue = $entryDetails['answer'];
+                                    }
+                                }
+
+                                $trimmedBmiValue = trim((string) $bmiValue);
+                                $inputID = 'bmi-input-'.$Questionnaire->id();
+                                $inputName = 'questionnaire_bmi['.$Questionnaire->id().']';
+
+                                if ($trimmedBmiValue === '') {
+                                    echo $Form->text($inputName, $bmiValue, 'input-simple', false, 'number', 'step="0.1" min="0"');
+                                } else {
+                                    echo '<div class="bmi-field">';
+                                    echo '<span class="js-bmi-display">'.PerchUtil::html($trimmedBmiValue).'</span>';
+                                    echo ' <button type="button" class="button button-simple js-bmi-edit" data-input-id="'.$inputID.'">Edit</button>';
+                                    echo '</div>';
+                                    echo $Form->text($inputName, $bmiValue, 'input-simple', false, 'number', 'step="0.1" min="0" id="'.$inputID.'" style="display:none;"');
+                                    $bmi_edit_controls_needed = true;
+                                }
+                            } else {
+                                echo PerchUtil::html($Questionnaire->answer_text());
+                            }
                             echo '</td>';
                             echo '</tr>';
                         }
@@ -293,7 +319,32 @@ echo '<span id="result-select'.PerchUtil::html($Document->documentID()).'" class
                             echo '<tr>';
                             echo '<td class="action">'.PerchUtil::html($question_label).'</td>';
                             echo '<td>';
-                            echo PerchUtil::html($Questionnaire->answer_text());
+                            if ($slug === 'bmi') {
+                                $bmiValue = $Questionnaire->answer_text();
+                                if ($bmiValue === null || $bmiValue === '') {
+                                    $entryDetails = $Questionnaire->to_array();
+                                    if (is_array($entryDetails) && isset($entryDetails['answer']) && $entryDetails['answer'] !== '') {
+                                        $bmiValue = $entryDetails['answer'];
+                                    }
+                                }
+
+                                $trimmedBmiValue = trim((string) $bmiValue);
+                                $inputID = 'bmi-input-'.$Questionnaire->id();
+                                $inputName = 'questionnaire_bmi['.$Questionnaire->id().']';
+
+                                if ($trimmedBmiValue === '') {
+                                    echo $Form->text($inputName, $bmiValue, 'input-simple', false, 'number', 'step="0.1" min="0"');
+                                } else {
+                                    echo '<div class="bmi-field">';
+                                    echo '<span class="js-bmi-display">'.PerchUtil::html($trimmedBmiValue).'</span>';
+                                    echo ' <button type="button" class="button button-simple js-bmi-edit" data-input-id="'.$inputID.'">Edit</button>';
+                                    echo '</div>';
+                                    echo $Form->text($inputName, $bmiValue, 'input-simple', false, 'number', 'step="0.1" min="0" id="'.$inputID.'" style="display:none;"');
+                                    $bmi_edit_controls_needed = true;
+                                }
+                            } else {
+                                echo PerchUtil::html($Questionnaire->answer_text());
+                            }
                             echo '</td>';
                             echo '</tr>';
                         }
@@ -309,6 +360,11 @@ echo '<span id="result-select'.PerchUtil::html($Document->documentID()).'" class
          </div>
 
     <?php
+        if (!empty($bmi_edit_controls_needed)) {
+            echo '<script>(function(){var buttons=document.querySelectorAll(".js-bmi-edit");if(!buttons.length){return;}Array.prototype.forEach.call(buttons,function(button){button.addEventListener("click",function(){var inputId=button.getAttribute("data-input-id");if(!inputId){return;}var input=document.getElementById(inputId);if(!input){return;}var container=button.parentNode;while(container&&!(container.className&&container.className.indexOf("bmi-field")!==-1)){container=container.parentNode;}if(container){var display=container.querySelector(".js-bmi-display");if(display){display.style.display="none";}}button.style.display="none";input.style.display="";input.focus();});});})();</script>';
+        }
+
+    ?>
 
 
           echo $HTML->heading2('Notes');

--- a/perch/addons/apps/perch_members/modes/members.edit.pre.php
+++ b/perch/addons/apps/perch_members/modes/members.edit.pre.php
@@ -108,6 +108,41 @@
 
         // Tags
         if ($result) {
+            if (is_object($Member) && isset($post['questionnaire_bmi']) && is_array($post['questionnaire_bmi'])) {
+                foreach ($post['questionnaire_bmi'] as $questionnaireID => $bmiValue) {
+                    $questionnaireID = (int) $questionnaireID;
+                    if ($questionnaireID <= 0) {
+                        continue;
+                    }
+
+                    $bmiValue = trim((string) $bmiValue);
+
+                    $QuestionnaireEntry = $Questionnaires->find($questionnaireID);
+                    if (!$QuestionnaireEntry) {
+                        continue;
+                    }
+
+                    if ((int) $QuestionnaireEntry->member_id() !== (int) $Member->id()) {
+                        continue;
+                    }
+
+                    $currentValue = trim((string) $QuestionnaireEntry->answer_text());
+                    if ($currentValue === $bmiValue) {
+                        continue;
+                    }
+
+                    $updateData = [
+                        'answer_text' => $bmiValue,
+                    ];
+
+                    $entryDetails = $QuestionnaireEntry->to_array();
+                    if (is_array($entryDetails) && array_key_exists('answer', $entryDetails)) {
+                        $updateData['answer'] = $bmiValue;
+                    }
+
+                    $QuestionnaireEntry->update($updateData);
+                }
+            }
 
             // existing tags
             $Tags->remove_from_member($Member->id(), $existing_tagIDs);


### PR DESCRIPTION
## Summary
- display stored BMI answers as read-only text with an Edit button that reveals the numeric input when needed
- reuse the same toggle behaviour across both questionnaire tables and inject supporting script once after rendering

## Testing
- php -l perch/addons/apps/perch_members/modes/members.edit.post.php

------
https://chatgpt.com/codex/tasks/task_b_68d53ad6e7b483248b94c48a9de491f4