### PR TITLE
Fix notes heading in members admin view

### DIFF
--- a/perch/addons/apps/perch_members/modes/members.edit.post.php
+++ b/perch/addons/apps/perch_members/modes/members.edit.post.php
@@ -367,9 +367,7 @@ echo '<span id="result-select'.PerchUtil::html($Document->documentID()).'" class
     ?>
 
 
-          echo $HTML->heading2('Notes');
-
-          ?>
+    <?php echo $HTML->heading2('Notes'); ?>
 
            <div class="form-inner">
                   <table class="notes">


### PR DESCRIPTION
## Summary
- ensure the Notes heading in the members admin view is rendered as HTML rather than printed as PHP code

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d56b7ca1488324a7ac15fd7901b556