### PR TITLE
Fix BMI edit inputs to handle stored category text

### DIFF
--- a/perch/addons/apps/perch_members/modes/members.edit.post.php
+++ b/perch/addons/apps/perch_members/modes/members.edit.post.php
@@ -247,14 +247,21 @@ echo '<span id="result-select'.PerchUtil::html($Document->documentID()).'" class
                                 $inputID = 'bmi-input-'.$Questionnaire->id();
                                 $inputName = 'questionnaire_bmi['.$Questionnaire->id().']';
 
+                                $numericBmiValue = '';
+                                if ($trimmedBmiValue !== '' && preg_match('/-?\d+(?:\.\d+)?/', $trimmedBmiValue, $matches)) {
+                                    $numericBmiValue = $matches[0];
+                                }
+
+                                $baseAttributes = 'step="0.1" min="0"';
+
                                 if ($trimmedBmiValue === '') {
-                                    echo $Form->text($inputName, $bmiValue, 'input-simple', false, 'number', 'step="0.1" min="0"');
+                                    echo $Form->text($inputName, $numericBmiValue, 'input-simple', false, 'number', $baseAttributes);
                                 } else {
                                     echo '<div class="bmi-field">';
                                     echo '<span class="js-bmi-display">'.PerchUtil::html($trimmedBmiValue).'</span>';
                                     echo ' <button type="button" class="button button-simple js-bmi-edit" data-input-id="'.$inputID.'">Edit</button>';
                                     echo '</div>';
-                                    echo $Form->text($inputName, $bmiValue, 'input-simple', false, 'number', 'step="0.1" min="0" id="'.$inputID.'" style="display:none;"');
+                                    echo $Form->text($inputName, $numericBmiValue, 'input-simple', false, 'number', $baseAttributes.' id="'.$inputID.'" style="display:none;"');
                                     $bmi_edit_controls_needed = true;
                                 }
                             } else {
@@ -332,14 +339,21 @@ echo '<span id="result-select'.PerchUtil::html($Document->documentID()).'" class
                                 $inputID = 'bmi-input-'.$Questionnaire->id();
                                 $inputName = 'questionnaire_bmi['.$Questionnaire->id().']';
 
+                                $numericBmiValue = '';
+                                if ($trimmedBmiValue !== '' && preg_match('/-?\d+(?:\.\d+)?/', $trimmedBmiValue, $matches)) {
+                                    $numericBmiValue = $matches[0];
+                                }
+
+                                $baseAttributes = 'step="0.1" min="0"';
+
                                 if ($trimmedBmiValue === '') {
-                                    echo $Form->text($inputName, $bmiValue, 'input-simple', false, 'number', 'step="0.1" min="0"');
+                                    echo $Form->text($inputName, $numericBmiValue, 'input-simple', false, 'number', $baseAttributes);
                                 } else {
                                     echo '<div class="bmi-field">';
                                     echo '<span class="js-bmi-display">'.PerchUtil::html($trimmedBmiValue).'</span>';
                                     echo ' <button type="button" class="button button-simple js-bmi-edit" data-input-id="'.$inputID.'">Edit</button>';
                                     echo '</div>';
-                                    echo $Form->text($inputName, $bmiValue, 'input-simple', false, 'number', 'step="0.1" min="0" id="'.$inputID.'" style="display:none;"');
+                                    echo $Form->text($inputName, $numericBmiValue, 'input-simple', false, 'number', $baseAttributes.' id="'.$inputID.'" style="display:none;"');
                                     $bmi_edit_controls_needed = true;
                                 }
                             } else {

--- a/perch/addons/apps/perch_members/modes/members.edit.pre.php
+++ b/perch/addons/apps/perch_members/modes/members.edit.pre.php
@@ -126,18 +126,32 @@
                         continue;
                     }
 
+                    $entryDetails = $QuestionnaireEntry->to_array();
+
                     $currentValue = trim((string) $QuestionnaireEntry->answer_text());
-                    if ($currentValue === $bmiValue) {
+                    if ($currentValue === '' && is_array($entryDetails) && isset($entryDetails['answer'])) {
+                        $currentValue = trim((string) $entryDetails['answer']);
+                    }
+
+                    $newValue = $bmiValue;
+
+                    if ($currentValue !== '' && strpos($currentValue, ',') !== false && strpos($newValue, ',') === false) {
+                        $suffix = trim((string) substr($currentValue, strpos($currentValue, ',') + 1));
+                        if ($suffix !== '') {
+                            $newValue .= ', '.$suffix;
+                        }
+                    }
+
+                    if ($currentValue === $newValue) {
                         continue;
                     }
 
                     $updateData = [
-                        'answer_text' => $bmiValue,
+                        'answer_text' => $newValue,
                     ];
 
-                    $entryDetails = $QuestionnaireEntry->to_array();
                     if (is_array($entryDetails) && array_key_exists('answer', $entryDetails)) {
-                        $updateData['answer'] = $bmiValue;
+                        $updateData['answer'] = $newValue;
                     }
 
                     $QuestionnaireEntry->update($updateData);


### PR DESCRIPTION
## Summary
- sanitize questionnaire BMI values before populating number inputs so the admin edit form can handle saved category text without browser errors
- retain any existing BMI category suffix when saving updated questionnaire answers to keep historical context

## Testing
- php -l perch/addons/apps/perch_members/modes/members.edit.post.php
- php -l perch/addons/apps/perch_members/modes/members.edit.pre.php

------
https://chatgpt.com/codex/tasks/task_b_68d6619d8d288324a89ce27b0aa51533