### PR TITLE
Add pregnancy question for female reorder members

### DIFF
--- a/perch/templates/forms/reorder-questionnaire.html
+++ b/perch/templates/forms/reorder-questionnaire.html
@@ -23,7 +23,7 @@
                         <label><input type="radio" onchange="radioweight(this.value)" name="weightradio-unit"  id="weightradio-lbs" value="st-lbs"> st/lbs</label>
                     </div>
                     <div class="buttons">
-                        <input type="hidden" id="nextstep" name="nextstep" value="side-effects">
+                        <input type="hidden" id="nextstep" name="nextstep" value="<perch:forms id='next_step_after_weight' />">
                         <button class="back"><a href="/client/re-order" style="text-decoration: none;color: #000;" >Back</a></button>
                         <button onclick="submitForm('weight')"   class="next"><span style="text-decoration: none;color: #000;" >Next →</span></button>
                     </div>
@@ -55,6 +55,37 @@
 
         </script>
     </perch:if>
+    <perch:if id="member_gender" value="Female">
+        <perch:if id="step" value="pregnancy-status">
+            <section class="how_old">
+                <div class="contanier">
+                    <div class="are_you">
+                        <div class="old_title">
+                            <h2>Are you pregnant or trying to conceive?</h2>
+                        </div>
+
+                        <div class="unde">
+                            <div class="button-group">
+                                <button id="yesBtn" onclick="setValuesreorderForm('pregnancy_status','yes')" class="custom_btn"><span style="text-decoration: none; color: #000;" >Yes</span></button>
+                                <button id="noBtn" onclick="setValuesreorderForm('pregnancy_status','no')" class="custom_btn"><span style="text-decoration: none; color: #000;" >No</span></button>
+                                <input type="hidden" id="nextstep" name="nextstep" value="side-effects">
+                                <input type="hidden" id="pregnancy_status" name="pregnancy_status" value="<perch:forms id='pregnancy_status' />">
+                            </div>
+                        </div>
+
+                        <div class="get_started">
+                            <div class="started_button">
+                                <div class="get_btn">
+                                    <button><a href="/client/questionnaire-re-order?step=weight">Back</a></button>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            </section>
+        </perch:if>
+    </perch:if>
     <perch:if id="step" value="side-effects">
         <section class="how_old">
             <div class="contanier">
@@ -85,7 +116,7 @@
                     <div class="get_started">
                         <div class="started_button">
                             <div class="get_btn">
-                                <button><a href="/client/questionnaire-re-order?step=weight">Back</a></button>
+                                <button><a href="/client/questionnaire-re-order?step=<perch:forms id='side_effects_back_step' />">Back</a></button>
                             </div>
                         </div>
                     </div>

--- a/perch/templates/pages/client/reorder-questionnaire.php
+++ b/perch/templates/pages/client/reorder-questionnaire.php
@@ -4,6 +4,23 @@ if (!perch_member_logged_in()) { exit;}
 if (empty($_SESSION['questionnaire-reorder']) && isset($_COOKIE['questionnaire_reorder'])) {
     $_SESSION['questionnaire-reorder'] = json_decode($_COOKIE['questionnaire_reorder'], true) ?: [];
 }
+
+$memberGender = perch_member_get('gender');
+$memberGender = is_string($memberGender) ? trim($memberGender) : '';
+$memberIsFemale = (strcasecmp($memberGender, 'Female') === 0);
+
+if (!$memberIsFemale && isset($_SESSION['questionnaire-reorder']['pregnancy_status'])) {
+    unset($_SESSION['questionnaire-reorder']['pregnancy_status']);
+}
+
+$pregnancyStatus = '';
+if (!empty($_SESSION['questionnaire-reorder']) && is_array($_SESSION['questionnaire-reorder'])) {
+    $pregnancyStatus = $_SESSION['questionnaire-reorder']['pregnancy_status'] ?? '';
+}
+
+$nextStepAfterWeight = $memberIsFemale ? 'pregnancy-status' : 'side-effects';
+$sideEffectsBackStep = $memberIsFemale ? 'pregnancy-status' : 'weight';
+$memberGenderForTemplate = $memberIsFemale ? 'Female' : $memberGender;
     //  echo "session";
       //  print_r($_SESSION);
  function generateUUID() {
@@ -128,9 +145,12 @@ if (empty($_SESSION['questionnaire-reorder']) && isset($_COOKIE['questionnaire_r
             <div id="product-selection">
                <h2 class="text-center fw-bolder">Before we send you your next dose we have a few questions! </h2>
     <?php
+PerchSystem::set_var('member_gender', $memberGenderForTemplate);
+PerchSystem::set_var('pregnancy_status', $pregnancyStatus);
+PerchSystem::set_var('next_step_after_weight', $nextStepAfterWeight);
+PerchSystem::set_var('side_effects_back_step', $sideEffectsBackStep);
 if(isset( $_GET["step"])){
-
-PerchSystem::set_var('step', $_GET["step"]);
+    PerchSystem::set_var('step', $_GET["step"]);
 }
 
  perch_form('reorder-questionnaire.html');


### PR DESCRIPTION
## Summary
- expose member gender details and supporting template variables to the reorder questionnaire page
- insert a female-only pregnancy question and adjust forward/back navigation for the reorder flow

## Testing
- php -l perch/templates/pages/client/reorder-questionnaire.php

------
https://chatgpt.com/codex/tasks/task_b_68d66bc458408324942cfe458c47092e