### PR TITLE
Update session gender when member profile is changed

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Member.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Member.class.php
@@ -65,7 +65,16 @@ class PerchMembers_Member extends PerchAPI_Base
 
     	$out['memberProperties'] = PerchUtil::json_safe_encode($properties);
 
-    	$this->update($out);
+        $this->update($out);
+
+        $Session = PerchMembers_Session::fetch();
+        if ($Session->logged_in && $Session->get('memberID') == $this->id()) {
+                if (array_key_exists('gender', $properties)) {
+                        $Session->set('gender', $properties['gender']);
+                } elseif (isset($data['gender'])) {
+                        $Session->set('gender', $data['gender']);
+                }
+        }
 
     }
 


### PR DESCRIPTION
## Summary
- refresh the member session gender value after a logged-in user updates their profile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d6a069371c8324b946e61e3ab0e345