### PR TITLE
Add fallback member link for lost order questions

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
@@ -805,6 +805,25 @@ class PerchMembers_Questionnaires extends PerchAPI_Factory
         return $this->return_instances($this->db->get_rows($sql));
     }
 
+    public function get_for_order($orderID, $type = null)
+    {
+        $sql = 'SELECT d.*
+                FROM  '.PERCH_DB_PREFIX.'questionnaire d
+                WHERE d.order_id='.$this->db->pdb((int)$orderID);
+
+        if ($type !== null) {
+            $sql .= ' AND d.type='.$this->db->pdb($type);
+        }
+
+        if ($this->questionOrderColumnAvailable()) {
+            $sql .= ' ORDER BY d.qid DESC, (d.question_order IS NULL), d.question_order ASC, d.created_at ASC, d.id ASC';
+        } else {
+            $sql .= ' ORDER BY d.id DESC';
+        }
+
+        return $this->return_instances($this->db->get_rows($sql));
+    }
+
 function displayUserAnswerHistoryUI(string $userId, string $logDir = 'logs') {
     $filePath = "/var/www/html/{$logDir}/{$userId}_raw_log.json";
 

--- a/perch/addons/apps/perch_shop_orders/lost/index.php
+++ b/perch/addons/apps/perch_shop_orders/lost/index.php
@@ -1,0 +1,5 @@
+<?php
+        $mode  = 'orders.lost';
+        $title = 'Lost Orders';
+
+        include('../_default_index.php');

--- a/perch/addons/apps/perch_shop_orders/modes/_order_smartbar.php
+++ b/perch/addons/apps/perch_shop_orders/modes/_order_smartbar.php
@@ -34,6 +34,12 @@
             'link'  => $API->app_nav().'/order/evidence/?id='.$Order->id(),
             'icon'  => 'ext/o-museum',
         ]);
+        $Smartbar->add_item([
+            'active' => $smartbar_selection=='questions',
+            'title' => $Lang->get('Questions'),
+            'link'  => $API->app_nav().'/order/questions/?id='.$Order->id(),
+            'icon'  => 'core/o-help',
+        ]);
         echo $HTML->title_panel([
             'button'  => [
              'text' => 'Download PDF',

--- a/perch/addons/apps/perch_shop_orders/modes/_subnav.php
+++ b/perch/addons/apps/perch_shop_orders/modes/_subnav.php
@@ -9,6 +9,7 @@
                                                 ],
                                 'label'=>'Orders'],
                 ['page'=>'perch_shop_orders/pending', 'label'=>'Pending Orders'],
+                ['page'=>'perch_shop_orders/lost', 'label'=>'Lost Orders'],
                 ['page'=>[
                                                 'perch_shop_orders/customers',
                                                 'perch_shop_orders/customers/edit',

--- a/perch/addons/apps/perch_shop_orders/modes/order.questions.post.php
+++ b/perch/addons/apps/perch_shop_orders/modes/order.questions.post.php
@@ -1,0 +1,83 @@
+<?php
+
+    $order_reference = $Order->orderInvoiceNumber();
+    if ($order_reference === '') {
+        $order_reference = '#'.$Order->id();
+    }
+
+    echo $HTML->title_panel([
+        'heading' => $Lang->get('Questions for %s', $order_reference),
+    ], $CurrentUser);
+
+    include('_order_smartbar.php');
+
+    echo '<div class="inner">';
+
+    $questions_rendered = false;
+
+    foreach ($questionnaire_sections as $section) {
+        $questions = isset($section['questions']) ? $section['questions'] : [];
+        $answers   = isset($section['answers']) ? $section['answers'] : [];
+
+        $answers_by_slug = [];
+        if (PerchUtil::count($answers)) {
+            foreach ($answers as $Answer) {
+                $slug = $Answer->question_slug();
+                if (!isset($answers_by_slug[$slug])) {
+                    $answers_by_slug[$slug] = $Answer;
+                }
+            }
+        }
+
+        echo '<h2>'.PerchUtil::html($section['title']).'</h2>';
+
+        if (!PerchUtil::count($answers_by_slug)) {
+            echo '<p>'.$Lang->get('No responses recorded for this questionnaire.').'</p>';
+            continue;
+        }
+
+        $questions_rendered = true;
+
+        echo '<div class="form-inner">';
+        echo '<table class="tags">';
+        echo '<thead>';
+        echo '<tr>';
+        echo '<th>'.$Lang->get('Question').'</th>';
+        echo '<th>'.$Lang->get('Answer').'</th>';
+        echo '</tr>';
+        echo '</thead>';
+        echo '<tbody>';
+
+        foreach ($questions as $slug => $label) {
+            if (!isset($answers_by_slug[$slug])) {
+                continue;
+            }
+
+            $Answer = $answers_by_slug[$slug];
+            $answer_text = $Answer->answer_text();
+            if ($answer_text === null || $answer_text === '') {
+                $answer_text = $Answer->answer();
+            }
+
+            if (is_array($answer_text)) {
+                $answer_text = implode(', ', array_map('strval', $answer_text));
+            }
+
+            $answer_text = trim((string) $answer_text);
+
+            echo '<tr>';
+            echo '<td class="action">'.PerchUtil::html($label).'</td>';
+            echo '<td>'.PerchUtil::html($answer_text).'</td>';
+            echo '</tr>';
+        }
+
+        echo '</tbody>';
+        echo '</table>';
+        echo '</div>';
+    }
+
+    if (!$questions_rendered) {
+        echo '<p>'.$Lang->get('No questionnaire responses were recorded for this order.').'</p>';
+    }
+
+    echo '</div>';

--- a/perch/addons/apps/perch_shop_orders/modes/order.questions.pre.php
+++ b/perch/addons/apps/perch_shop_orders/modes/order.questions.pre.php
@@ -1,0 +1,52 @@
+<?php
+
+        $Orders     = new PerchShop_Orders($API);
+        $Customers  = new PerchShop_Customers($API);
+        $Form       = $API->get('Form');
+        $message    = false;
+        $smartbar_selection = 'questions';
+
+        if (!class_exists('PerchMembers_Questionnaires')) {
+            include_once(PERCH_PATH.'/addons/apps/perch_members/PerchMembers_Questionnaires.class.php');
+        }
+
+        $MembersAPI = new PerchAPI(1.0, 'perch_members');
+        $Questionnaires = new PerchMembers_Questionnaires($MembersAPI);
+
+        $questionnaire_sections = [];
+
+        if (PerchUtil::get('id')) {
+
+                if (!$CurrentUser->has_priv('perch_shop.orders.edit')) {
+                    PerchUtil::redirect($API->app_path());
+                }
+
+                $order_id = (int) PerchUtil::get('id');
+
+                $Order = $Orders->find($order_id);
+
+                if (!$Order) {
+                    PerchUtil::redirect($API->app_path());
+                }
+
+                $Customer = $Customers->find($Order->customerID());
+
+                $questionnaire_sections = [
+                    [
+                        'type'      => 'first-order',
+                        'title'     => $Lang->get('First-order questionnaire'),
+                        'questions' => $Questionnaires->get_questions('first-order'),
+                        'answers'   => $Questionnaires->get_for_order($order_id, 'first-order'),
+                    ],
+                    [
+                        'type'      => 're-order',
+                        'title'     => $Lang->get('Re-order questionnaire'),
+                        'questions' => $Questionnaires->get_questions('re-order'),
+                        'answers'   => $Questionnaires->get_for_order($order_id, 're-order'),
+                    ],
+                ];
+
+        }else{
+            PerchUtil::redirect($API->app_path());
+        }
+

--- a/perch/addons/apps/perch_shop_orders/modes/orders.list.post.php
+++ b/perch/addons/apps/perch_shop_orders/modes/orders.list.post.php
@@ -1,7 +1,7 @@
 <?php 
 
 echo $HTML->title_panel([
-    'heading' => $Lang->get('Listing all orders'),
+    'heading' => isset($list_heading) ? $list_heading : $Lang->get('Listing all orders'),
     'button'  => [
         'text' => $Lang->get('Add order'),
         'link' => $API->app_nav().'/order/edit/',
@@ -139,6 +139,32 @@ echo $HTML->title_panel([
             },
             'sort'      => 'billing_type',
         ]);
+
+    if (!empty($show_question_link)) {
+        $Listing->add_col([
+            'title'     => 'Questions',
+            'value'     => function($Item) use ($API, $Lang, $Customers) {
+                $order_id = (int)$Item->id();
+                if ($order_id > 0) {
+                    $url = $API->app_nav().'/order/questions/?id='.$order_id;
+                    $label = $Lang->get('Questions');
+                    return '<a class="button button-simple" target="_blank" rel="noopener" href="'.$url.'">'.$label.'</a>';
+                }
+
+                $customer_id = (int)$Item->customerID();
+                if ($customer_id > 0) {
+                    $Customer = $Customers->find($customer_id);
+                    if ($Customer && $Customer->memberID()) {
+                        $url = '/perch/addons/apps/perch_members/edit/?id='.$Customer->memberID();
+                        $label = $Lang->get('Member profile');
+                        return '<a class="button button-simple" target="_blank" rel="noopener" href="'.$url.'">'.$label.'</a>';
+                    }
+                }
+
+                return '';
+            },
+        ]);
+    }
     
  $Listing->add_col([
             'title'     => 'Send To pharmacy',

--- a/perch/addons/apps/perch_shop_orders/modes/orders.list.pre.php
+++ b/perch/addons/apps/perch_shop_orders/modes/orders.list.pre.php
@@ -4,6 +4,7 @@
 $sort="^orderCreated";
         $Orders   = new PerchShop_Orders($API);
         $OrderItems = new PerchShop_OrderItems($API);
+        $Customers = new PerchShop_Customers($API);
         $Statuses = new PerchShop_OrderStatuses($API);
         $Tags = new PerchMembers_Tags($API);
  $Documents = new PerchMembers_Documents($API);

--- a/perch/addons/apps/perch_shop_orders/modes/orders.lost.post.php
+++ b/perch/addons/apps/perch_shop_orders/modes/orders.lost.post.php
@@ -1,0 +1,4 @@
+<?php
+        $list_heading = $Lang->get('Listing lost orders');
+        $show_question_link = true;
+        include(__DIR__.'/orders.list.post.php');

--- a/perch/addons/apps/perch_shop_orders/modes/orders.lost.pre.php
+++ b/perch/addons/apps/perch_shop_orders/modes/orders.lost.pre.php
@@ -1,0 +1,5 @@
+<?php
+        $default_statuses = ['lost'];
+        $list_heading = $Lang->get('Listing lost orders');
+        $show_question_link = true;
+        include(__DIR__.'/orders.list.pre.php');

--- a/perch/addons/apps/perch_shop_orders/order/questions/index.php
+++ b/perch/addons/apps/perch_shop_orders/order/questions/index.php
@@ -1,0 +1,5 @@
+<?php
+        $mode  = 'order.questions';
+        $title = 'Order Questions';
+
+        include('../../_default_index.php');


### PR DESCRIPTION
## Summary
- prepare the orders listing with a customer repository so we can resolve members from lost orders
- fall back to linking to the member edit screen when an order record is missing for the questions button

## Testing
- php -l perch/addons/apps/perch_shop_orders/modes/orders.list.pre.php
- php -l perch/addons/apps/perch_shop_orders/modes/orders.list.post.php

------
https://chatgpt.com/codex/tasks/task_b_68d6b140b014832487c97d6bc5eb10f5