### PR TITLE
Format weight questionnaire answers to two decimals

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
@@ -789,6 +789,23 @@ class PerchMembers_Questionnaires extends PerchAPI_Factory
 
         return is_scalar($value) ? trim((string)$value) : '';
     }
+
+    protected function formatWeightValue($value): string
+    {
+        if (is_string($value)) {
+            $value = trim($value);
+        }
+
+        if ($value === '' || $value === null) {
+            return '';
+        }
+
+        if (is_numeric($value)) {
+            return number_format((float)$value, 2, '.', '');
+        }
+
+        return is_scalar($value) ? (string)$value : '';
+    }
         public function get_for_member($memberID,$type="first-order")
     {
         $sql = 'SELECT d.*
@@ -1642,6 +1659,12 @@ $Members = new PerchMembers_Members;
           } else {
               $qdata['answer_text'] = '';
           }
+
+      $isMedicationWeightQuestion = (strpos($key, 'weight-') === 0);
+      if (($key === 'weight' || $isMedicationWeightQuestion) && $qdata['answer_text'] !== '') {
+          $qdata['answer_text'] = $this->formatWeightValue($qdata['answer_text']);
+      }
+
       if ($key === 'weight') {
           $weightunit = array_values(array_filter(array_map('trim', explode('-', (string)$weightUnitValue)), 'strlen'));
           if (!empty($weightunit) && $qdata['answer_text'] !== '') {
@@ -1651,7 +1674,7 @@ $Members = new PerchMembers_Members;
                   $qdata['answer_text'] .= ' ' . $weightunit[0];
                   $secondWeight = $data['weight2'] ?? null;
                   if ($secondWeight !== null && $secondWeight !== '') {
-                      $qdata['answer_text'] .= ' ' . $secondWeight;
+                      $qdata['answer_text'] .= ' ' . $this->formatWeightValue($secondWeight);
                       if (isset($weightunit[1])) {
                           $qdata['answer_text'] .= ' ' . $weightunit[1];
                       }
@@ -1690,7 +1713,7 @@ $Members = new PerchMembers_Members;
                         $qdata['answer_text'] .= ' ' . $unitParts[0];
                         $secondKey = "weight2-{$slug}";
                         if (isset($data[$secondKey]) && $data[$secondKey] !== '') {
-                            $qdata['answer_text'] .= ' ' . $data[$secondKey];
+                            $qdata['answer_text'] .= ' ' . $this->formatWeightValue($data[$secondKey]);
                             if (isset($unitParts[1])) {
                                 $qdata['answer_text'] .= ' ' . $unitParts[1];
                             }

--- a/perch/templates/pages/getStarted/review-questionnaire.php
+++ b/perch/templates/pages/getStarted/review-questionnaire.php
@@ -97,13 +97,28 @@ foreach ($medicationSlugs as $slug) {
     $steps["recently-dose-{$slug}"] = "recently_wegovy";
 }
 
+function formatMeasurementNumber($value)
+{
+    if ($value === null || $value === '') {
+        return '';
+    }
+
+    if (is_numeric($value)) {
+        return number_format((float) $value, 2, '.', '');
+    }
+
+    return (string) $value;
+}
+
 // Render a field with optional second value and unit
 function renderMeasurement($value, $unitKey, $secondKey, $questionnaire)
 {
     $parts = [];
+    $isWeightMeasurement = $unitKey === 'weightunit' || strpos($unitKey, 'unit-') === 0;
 
     if ($value !== null && $value !== '') {
-        $parts[] = htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
+        $displayValue = $isWeightMeasurement ? formatMeasurementNumber($value) : (string) $value;
+        $parts[] = htmlspecialchars($displayValue, ENT_QUOTES, 'UTF-8');
     }
 
     if (!empty($questionnaire[$unitKey])) {
@@ -111,7 +126,11 @@ function renderMeasurement($value, $unitKey, $secondKey, $questionnaire)
         $parts[] = htmlspecialchars($unitParts[0], ENT_QUOTES, 'UTF-8');
 
         if ((isset($questionnaire[$secondKey]) || array_key_exists($secondKey, $questionnaire)) && isset($unitParts[1])) {
-            $parts[] = htmlspecialchars((string) $questionnaire[$secondKey], ENT_QUOTES, 'UTF-8');
+            $secondValue = $questionnaire[$secondKey] ?? '';
+            if ($isWeightMeasurement) {
+                $secondValue = formatMeasurementNumber($secondValue);
+            }
+            $parts[] = htmlspecialchars((string) $secondValue, ENT_QUOTES, 'UTF-8');
             $parts[] = htmlspecialchars($unitParts[1], ENT_QUOTES, 'UTF-8');
         }
     }


### PR DESCRIPTION
## Summary
- format questionnaire weight answers to two decimal places when saving responses
- ensure review page renders weight measurements with two decimal precision

## Testing
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
- php -l perch/templates/pages/getStarted/review-questionnaire.php

------
https://chatgpt.com/codex/tasks/task_b_68daa6baeacc83248236815f1527e118