### PR TITLE
Set default display for missing other medication details

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
@@ -1660,6 +1660,10 @@ $Members = new PerchMembers_Members;
               $qdata['answer_text'] = '';
           }
 
+          if ($key === 'other_medication_details' && trim((string)$qdata['answer_text']) === '') {
+              $qdata['answer_text'] = 'No medication being taken.';
+          }
+
       $isMedicationWeightQuestion = (strpos($key, 'weight-') === 0);
       if (($key === 'weight' || $isMedicationWeightQuestion) && $qdata['answer_text'] !== '') {
           $qdata['answer_text'] = $this->formatWeightValue($qdata['answer_text']);

--- a/perch/templates/pages/getStarted/review-questionnaire.php
+++ b/perch/templates/pages/getStarted/review-questionnaire.php
@@ -187,7 +187,12 @@ $_SESSION['questionnaire']["reviewed"] = "InProcess";
                         } elseif ($key === "height") {
                             echo renderMeasurement($value, "heightunit", "height2", $_SESSION['questionnaire']);
                         } else {
-                            echo htmlspecialchars($value);
+                            $displayValue = $value;
+                            if ($key === "other_medication_details" && trim((string)$displayValue) === '') {
+                                $displayValue = 'No medication being taken.';
+                            }
+
+                            echo htmlspecialchars((string)$displayValue);
                         }
                         ?>
                     </p>


### PR DESCRIPTION
## Summary
- fill in a default "No medication being taken." response when `other_medication_details` is left blank in questionnaire data
- ensure the review questionnaire page shows the same default text when no details are provided

## Testing
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
- php -l perch/templates/pages/getStarted/review-questionnaire.php

------
https://chatgpt.com/codex/tasks/task_b_68daa9bd4bac8324a5731f4e4ff16277