### PR TITLE
Summarize multi-medication questionnaire answers

### DIFF
--- a/perch/addons/apps/perch_members/questionnaire_medication_helpers.php
+++ b/perch/addons/apps/perch_members/questionnaire_medication_helpers.php
@@ -12,7 +12,7 @@ if (!function_exists('perch_questionnaire_medications')) {
             'alli' => 'Alli',
             'mysimba' => 'Mysimba',
             'other' => 'the weight loss medication',
-            'none' => 'None',
+            'none' => 'I have never taken medication to lose weight',
         ];
     }
 }

--- a/perch/templates/pages/getStarted/review-questionnaire.php
+++ b/perch/templates/pages/getStarted/review-questionnaire.php
@@ -170,7 +170,22 @@ $_SESSION['questionnaire']["reviewed"] = "InProcess";
                     <p>
                         <?php
                         if (is_array($value)) {
-                            echo htmlspecialchars(implode(", ", $value));
+                            if ($key === 'medications') {
+                                $labels = [];
+                                foreach ($value as $rawSelection) {
+                                    $slug = perch_questionnaire_medication_slug((string) $rawSelection);
+                                    if ($slug === '') {
+                                        continue;
+                                    }
+
+                                    $labels[] = perch_questionnaire_medication_label($slug);
+                                }
+
+                                $labels = array_values(array_unique(array_filter($labels, static fn($label) => trim((string) $label) !== '')));
+                                echo htmlspecialchars(implode(', ', $labels));
+                            } else {
+                                echo htmlspecialchars(implode(", ", $value));
+                            }
                         } elseif ($key === "weight") {
                             echo renderMeasurement($value, "weightunit", "weight2", $_SESSION['questionnaire']);
                         } elseif (strpos($key, 'weight-') === 0) {


### PR DESCRIPTION
## Summary
- aggregate weight and dosing answers for each selected medication into the medications question when storing questionnaire submissions
- align the "never taken medication" option label and review page rendering with the stored medication labels so admins see human-friendly values

## Testing
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
- php -l perch/addons/apps/perch_members/questionnaire_medication_helpers.php
- php -l perch/templates/pages/getStarted/review-questionnaire.php

------
https://chatgpt.com/codex/tasks/task_b_68daac08d6688324bc3c1cfe88a184e2