### PR TITLE
Fix questionnaire question order tracking

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
@@ -1579,6 +1579,10 @@ $Members = new PerchMembers_Members;
          $new_id =$this->db->execute($insert_status);
       $data['bmi']=$result;
       $sessionKey = $new_id ?: ($memberID . ':' . $type);
+      $sessionQuestionOrderMap = [];
+      if (isset($_SESSION['questionnaire_question_order']) && is_array($_SESSION['questionnaire_question_order'])) {
+          $sessionQuestionOrderMap = $_SESSION['questionnaire_question_order'];
+      }
 
       $weightUnitValue = $data['weightunit'] ?? ($data['weightunit-radio'] ?? ($data['weightradio-unit'] ?? ''));
       $heightUnitValue = $data['heightunit'] ?? ($data['heightunit-radio'] ?? '');
@@ -1642,11 +1646,19 @@ $Members = new PerchMembers_Members;
           $qdata['type'] = $type;
           $qdata['question_slug'] = $key;
           $qdata['question_text'] = $questionConfig['label'] ?? ($questionLookup[$key] ?? $key);
-         // $questionOrder = $this->getQuestionOrderForSession($sessionKey, $type, $key);
-          /*if ($questionOrder !== null) {
-              $qdata['question_order'] = $questionOrder;
-          }*/
- $qdata['question_order'] = $data[$key]["questionOrder"];
+
+          $questionOrder = null;
+          if (is_array($value) && array_key_exists('questionOrder', $value)) {
+              $questionOrder = $value['questionOrder'];
+          } elseif (isset($sessionQuestionOrderMap[$key])) {
+              $questionOrder = $sessionQuestionOrderMap[$key];
+          } else {
+              $questionOrder = $this->getQuestionOrderForSession($sessionKey, $type, $key);
+          }
+
+          if ($questionOrder !== null) {
+              $qdata['question_order'] = (int) $questionOrder;
+          }
           if ($questionConfig) {
               $qdata['answer_text'] = $this->resolveAnswerTextFromConfig($value, $questionConfig);
           } elseif (is_array($value)) {

--- a/perch/templates/pages/getStarted/questionnaire.php
+++ b/perch/templates/pages/getStarted/questionnaire.php
@@ -150,11 +150,15 @@ $cookieQuestionnaire = isset($_COOKIE['questionnaire'])
 if (!isset($_SESSION['questionnaire']) || empty($_SESSION['questionnaire'])) {
     $_SESSION['questionnaire'] = $cookieQuestionnaire;
 }
+if (!isset($_SESSION['questionnaire_question_order']) || !is_array($_SESSION['questionnaire_question_order'])) {
+    $_SESSION['questionnaire_question_order'] = [];
+}
 
 $previousPage = $_SERVER['HTTP_REFERER'] ?? 'No referrer';
 $redirect=true;
 if (isset($_GET['step']) && $_GET['step'] === 'startagain') {
     $_SESSION['questionnaire'] = [];
+    $_SESSION['questionnaire_question_order'] = [];
     setcookie('questionnaire', '', time()-3600, '/');
     header("Location: /get-started/questionnaire?step=howold");
     exit();
@@ -196,6 +200,7 @@ if (isset($_POST['nextstep'])) {
             isset($_SESSION['questionnaire']['pregnancy'])
         ) {
             unset($_SESSION['questionnaire']['pregnancy']);
+            unset($_SESSION['questionnaire_question_order']['pregnancy']);
         }
 
         if (
@@ -203,6 +208,7 @@ if (isset($_POST['nextstep'])) {
             $_SESSION['questionnaire']['weightunit'] === 'kg'
         ) {
             unset($_SESSION['questionnaire']['weight2']);
+            unset($_SESSION['questionnaire_question_order']['weight2']);
         }
 
         if (
@@ -210,6 +216,7 @@ if (isset($_POST['nextstep'])) {
             $_SESSION['questionnaire']['heightunit'] == 'cm'
         ) {
             unset($_SESSION['questionnaire']['height2']);
+            unset($_SESSION['questionnaire_question_order']['height2']);
         }
       /*  if ($key == 'diabetes') {
         $redirect=false;
@@ -221,8 +228,9 @@ if (isset($_POST['nextstep'])) {
             } else {
                 $_SESSION['questionnaire'][$key] = htmlspecialchars($value);
             }
-  $_SESSION['questionnaire'][$key]["question_order"]=  $_SESSION['question_order'];
-   $_SESSION['question_order']++;
+
+            $_SESSION['questionnaire_question_order'][$key] = $_SESSION['question_order'];
+            $_SESSION['question_order']++;
 
             // Log answer
             $loggedValue = is_array($_SESSION['questionnaire'][$key])

--- a/perch/templates/pages/payment/stripe/index.php
+++ b/perch/templates/pages/payment/stripe/index.php
@@ -111,6 +111,9 @@ if (empty($_SESSION['questionnaire-reorder']) && isset($_COOKIE['questionnaire_r
              }
 
              $_SESSION['questionnaire'] = array();
+             if (isset($_SESSION['questionnaire_question_order'])) {
+                 $_SESSION['questionnaire_question_order'] = [];
+             }
             setcookie('questionnaire', '', time()-3600, '/');
             }
 


### PR DESCRIPTION
## Summary
- record questionnaire answer ordering in a dedicated session map instead of mutating scalar answers
- use the stored ordering map (with a dynamic fallback) when persisting questionnaire responses
- reset the ordering map whenever questionnaire data are cleared

## Testing
- php -l perch/templates/pages/getStarted/questionnaire.php
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
- php -l perch/templates/pages/payment/stripe/index.php

------
https://chatgpt.com/codex/tasks/task_b_68dba9aca1a4832492842d8aff5d2dea