### PR TITLE
Remove contact step from reorder questionnaire

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
@@ -260,10 +260,9 @@ class PerchMembers_Questionnaires extends PerchAPI_Factory
 	"list_additional_medication"=>"Please tell us as much as you can about your  additional medication",
 	"rate_current_experience"=>"Are you happy with your monthly weight loss?",
 	"no_happy_reasons"=>"Please tell us as much as you can about the reasons you are not happy with your monthly weight loss.",
-	"chat_with_us"=>"Would you like to chat with someone?",
-	"email_address"=>"Please enter your  email address",
-	 "multiple_answers"=>"Have client alter answers?",
-	 "documents"=>"Member Documents",
+        "chat_with_us"=>"Would you like to chat with someone?",
+        "multiple_answers"=>"Have client alter answers?",
+        "documents"=>"Member Documents",
 	];
 	public $steps=[
     "age"=>"howold",
@@ -374,11 +373,6 @@ class PerchMembers_Questionnaires extends PerchAPI_Factory
                 "yes" => "Yes",
                 "no" => "No"
             ]
-        ],
-        "email_address" => [
-            "label" => "Please enter your  email address",
-            "type" => "text",
-            "name" => "email_address"
         ]
     ];
 
@@ -924,11 +918,11 @@ function getNextStepforFirstOrder(array $data): string {
     }
 
     if (isset($data['rate_current_experience'])) {
-        return $data['rate_current_experience'] === 'no' ? 'no-happy' : 'contact';
+        return $data['rate_current_experience'] === 'no' ? 'no-happy' : 'chat_with_us';
     }
 
     if (isset($data['chat_with_us'])) {
-        return $data['chat_with_us'] === 'no' ? 'cart' : 'contact';
+        return 'cart';
     }
 
     if (isset($data['pregnancy'])) {

--- a/perch/addons/apps/perch_members/questionnaire_default_questions.php
+++ b/perch/addons/apps/perch_members/questionnaire_default_questions.php
@@ -102,19 +102,6 @@ return [
                 'no' => 'No',
             ],
             'step' => 'chat_with_us',
-            'dependencies' => [
-                [
-                    'values' => ['yes'],
-                    'question' => 'email_address',
-                    'step' => 'contact',
-                ],
-            ],
-        ],
-        'email_address' => [
-            'label' => 'Please enter your email address',
-            'type' => 'text',
-            'name' => 'email_address',
-            'step' => 'contact',
         ],
     ],
     'first-order' => [

--- a/perch/templates/forms/reorder-questionnaire.html
+++ b/perch/templates/forms/reorder-questionnaire.html
@@ -246,7 +246,7 @@
                         <div class="button-group">
                             <button id="yesBtn" onclick="setValuesreorderForm('rate_current_experience','yes')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >Yes</span></button>
                             <button id="noBtn" onclick="setValuesreorderForm('rate_current_experience','no')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >No</span></button>
-                            <input type="hidden" id="nextstep" name="nextstep" value="contact">
+                            <input type="hidden" id="nextstep" name="nextstep" value="chat_with_us">
                             <input type="hidden" id="rate_current_experience" name="rate_current_experience" value="">
 
 
@@ -284,7 +284,7 @@
                     <div class="buttons">
                         <button type="button" class="back"><a style="text-decoration: none;
                                     color: #000;" href="/client/questionnaire-re-order?step=rate_current_experience">Back</a></button>
-                        <input type="hidden" id="nextstep" name="nextstep" value="contact">
+                        <input type="hidden" id="nextstep" name="nextstep" value="chat_with_us">
                         <button type="submit"  onclick="submitForm('no_happy_reasons')"  class="next"><span style="text-decoration: none; color: #000;" >Next →</span></button>
 
                     </div>
@@ -317,7 +317,7 @@
                         <div class="button-group">
                             <button id="yesBtn" onclick="setValuesreorderForm('chat_with_us','yes')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >Yes</span></button>
                             <button id="noBtn" onclick="setValuesreorderForm('chat_with_us','no')"  class="custom_btn"><span style="text-decoration: none; color: #000;" >No</span></button>
-                            <input type="hidden" id="nextstep" name="nextstep" value="contact">
+                            <input type="hidden" id="nextstep" name="nextstep" value="cart">
                             <input type="hidden" id="chat_with_us" name="chat_with_us" value="">
 
 
@@ -335,43 +335,6 @@
                 </div>
             </div>
         </section>
-    </perch:if>
-
-    <perch:if id="step" value="contact" >
-
-        <section class="how_old ">
-            <div class="mixed">
-                <div class="bar">
-                    <!--  <div class="progress_bar">
-                      <div class="nambar">
-                          <span>22%</span>
-                      </div>
-
-                  </div>-->
-                </div>
-                <h2>Please enter your  email address</h2>
-                <div class="weight-inputs">
-                    <input type="text" id="email_address"  name="email_address" placeholder="e-mail address" style="width: 100%;" >
-
-                    <input type="hidden" id="nextstep" name="nextstep" value="cart">
-
-                </div>
-
-
-                <div class="buttons skip ">
-                    <button class="back skip_button "><a href="/order/cart" style="text-decoration: none;color: #000;" >Skip</a></button>
-                </div>
-
-
-                <div class="buttons">
-                    <button class="back"><a href="/client/questionnaire-re-order?step=chat_with_us" style="text-decoration: none;color: #000;" >Back</a></button>
-                    <button onclick="submitForm('email_address')" class="next"><span style="text-decoration: none;color: #000;" >Next →</span></button>
-                </div>
-            </div>
-        </section>
-
-
-
     </perch:if>
 
 </perch:form>


### PR DESCRIPTION
## Summary
- remove the contact step from the reorder questionnaire template so the flow now routes straight from chat choices to the cart
- drop the email address question and dependency from the reorder default question configuration
- update the questionnaire logic to skip the contact step when determining the next step for reorder submissions

## Testing
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
- php -l perch/addons/apps/perch_members/questionnaire_default_questions.php

------
https://chatgpt.com/codex/tasks/task_b_68dc0031128c8324ab02aba8f1f06fc6