### PR TITLE
Require customers to accept terms during registration

### DIFF
--- a/perch/addons/apps/perch_shop/templates/shop/checkout/customer_create_wl.html
+++ b/perch/addons/apps/perch_shop/templates/shop/checkout/customer_create_wl.html
@@ -113,10 +113,10 @@
 	</div>
 
 	<hr>
-	<div class="agree_weightloss py-4">
-		<perch:input type="checkbox" checked="unchecked" name="agree" id="agree" />
-		<span>Yes, I agree to GetWeightLoss's <a href="/terms-and-conditions" target="_blank" style="color: #288881; text-decoration: none; padding: 0 2px;">Terms & Conditions</a> And <a href="/privacy-notice" target="_blank" style="color: #288881; text-decoration: none; padding: 0 2px;">Privacy Policy.</a></span>
-	</div>
+        <div class="agree_weightloss py-4">
+                <perch:input type="checkbox" name="agree" id="agree" required="true" />
+                <span>Yes, I agree to GetWeightLoss's <a href="/terms-and-conditions" target="_blank" style="color: #288881; text-decoration: none; padding: 0 2px;">Terms & Conditions</a> And <a href="/privacy-notice" target="_blank" style="color: #288881; text-decoration: none; padding: 0 2px;">Privacy Policy.</a></span>
+        </div>
 	<div class="do_not pb-4">
 		<perch:input type="checkbox" checked="" name="agree" id="agree-marketing"/>
 		<span>I do not wish to receive marketing communications that include special offers, promotions, or educational content. </span>


### PR DESCRIPTION
## Summary
- make the registration terms and conditions checkbox unchecked by default
- mark the terms agreement as required so the form cannot be submitted until it is accepted

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dcfa42c0a0832480b89342434b695a