### PR TITLE
Prevent special offers email from overriding GP email

### DIFF
--- a/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
+++ b/perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
@@ -292,7 +292,7 @@ class PerchMembers_Questionnaires extends PerchAPI_Factory
     "wegovy_side_effects"=>"wegovy_side_effects",
     "gp_informed"=>"gp_informed",
     "GP_email_address"=>"gp_address",
-    "Get access to special offers"=>"access_special_offers"
+    "special_offers_email"=>"access_special_offers"
     ];
     public $reorder_questions_answers = [
         "weight" => [
@@ -627,9 +627,16 @@ class PerchMembers_Questionnaires extends PerchAPI_Factory
                                        "email_address" => [
                                            "label" => "Please enter your GP's email address",
                                            "type" => "text",
-                                           "name" => "email_address"
+                                           "name" => "email_address",
+                                           "step" => "gp_address"
+                                       ],
+                                       "special_offers_email" => [
+                                           "label" => "Get access to special offers",
+                                           "type" => "text",
+                                           "name" => "special_offers_email",
+                                           "step" => "access_special_offers"
                                        ]
-                                   ];
+                                  ];
 
 
 		public $questions=[
@@ -665,7 +672,7 @@ class PerchMembers_Questionnaires extends PerchAPI_Factory
     "wegovy_side_effects"=>"Please tell us as much as you can about your side effects - the type, duration, severity and whether they have resolved",
     "gp_informed"=>"Would you like your GP to be informed of this consultation?",
     "email_address"=>"Please enter your GP's email address",
-    "Get access to special offers"=>"email_address",
+    "special_offers_email"=>"Get access to special offers",
     "multiple_answers"=>"Have client alter answers?",
     "documents"=>"Member Documents",
     "bmi"=>"BMI",
@@ -1611,7 +1618,7 @@ $Members = new PerchMembers_Members;
       foreach ($data as $key => $value) {
           $questionConfig = $questionConfigSet[$key] ?? null;
 
-          if ($key === 'email_address') {
+          if ($key === 'email_address' || $key === 'special_offers_email') {
               $emailValue = '';
               if (is_array($value)) {
                   $firstEmail = reset($value);
@@ -1624,7 +1631,7 @@ $Members = new PerchMembers_Members;
 
               if ($emailValue === '') {
                   $questionStep = is_array($questionConfig) ? ($questionConfig['step'] ?? null) : null;
-                  if ($questionStep === 'access_special_offers') {
+                  if ($questionStep === 'access_special_offers' || $key === 'special_offers_email') {
                       $value = 'skipped';
                   } else {
                       $value = 'no-email-added';

--- a/perch/addons/apps/perch_members/questionnaire_default_questions.php
+++ b/perch/addons/apps/perch_members/questionnaire_default_questions.php
@@ -526,7 +526,7 @@ return [
         'access_special_offers' => [
             'label' => 'Get access to special offers',
             'type' => 'text',
-            'name' => 'email_address',
+            'name' => 'special_offers_email',
             'step' => 'access_special_offers',
         ],
     ],

--- a/perch/templates/forms/questionnaire.html
+++ b/perch/templates/forms/questionnaire.html
@@ -2150,7 +2150,7 @@
                     <h2>Get access to special offers</h2>
                     <p style="font-weight: 600;" >Take the first step towards improving your metabolic health. You'll receive personalised health insights and exclusive monthly offers available only to Get Weight Loss members.</p>
                     <div class="weight-inputs">
-                        <input type="text" id="email_address" name="email_address" placeholder="Email address (optional)" style="width: 100%;" >
+                        <input type="text" id="special_offers_email" name="special_offers_email" placeholder="Email address (optional)" style="width: 100%;" >
 
 
 

--- a/perch/templates/pages/getStarted/review-questionnaire.php
+++ b/perch/templates/pages/getStarted/review-questionnaire.php
@@ -32,7 +32,7 @@ $questions = [
     "wegovy_side_effects" => "Please tell us as much as you can about your side effects - the type, duration, severity and whether they have resolved",
     "gp_informed" => "Would you like your GP to be informed of this consultation?",
     "email_address" => "Please enter your GP's email address",
-    "Get access to special offers" => "email_address"
+    "special_offers_email" => "Get access to special offers"
 ];
 
 $doseOptions = [
@@ -88,7 +88,7 @@ $steps = [
     "wegovy_side_effects" => "wegovy_side_effects",
     "gp_informed" => "gp_informed",
     "email_address" => "gp_address",
-    "Get access to special offers" => "access_special_offers"
+    "special_offers_email" => "access_special_offers"
 ];
 
 foreach ($medicationSlugs as $slug) {


### PR DESCRIPTION
## Summary
- add a dedicated special_offers_email field and step mapping so the optional marketing email no longer reuses the GP email slot
- update questionnaire configuration, storage logic, and review output to work with the new field name

## Testing
- php -l perch/addons/apps/perch_members/PerchMembers_Questionnaires.class.php
- php -l perch/addons/apps/perch_members/questionnaire_default_questions.php
- php -l perch/templates/pages/getStarted/review-questionnaire.php

------
https://chatgpt.com/codex/tasks/task_b_68dd06a7eaa08324b8bb5aff47e4ef03