### PR TITLE
Show GP email in order questions tab

### DIFF
--- a/perch/addons/apps/perch_members/modes/members.edit.post.php
+++ b/perch/addons/apps/perch_members/modes/members.edit.post.php
@@ -265,7 +265,10 @@ echo '<span id="result-select'.PerchUtil::html($Document->documentID()).'" class
                                     $bmi_edit_controls_needed = true;
                                 }
                             } else {
-                                echo PerchUtil::html($Questionnaire->answer_text());
+                                $answerText = (string)$Questionnaire->answer_text();
+                                $output = PerchUtil::html($answerText);
+
+                                echo $output;
                             }
                             echo '</td>';
                             echo '</tr>';

--- a/perch/addons/apps/perch_shop_orders/modes/order.questions.post.php
+++ b/perch/addons/apps/perch_shop_orders/modes/order.questions.post.php
@@ -71,7 +71,42 @@
                             }
             echo '<tr>';
             echo '<td class="action">'.PerchUtil::html($label).'</td>';
-            echo '<td>'.PerchUtil::html($answer_text).'</td>';
+
+            $output = PerchUtil::html($answer_text);
+
+            if ($slug === 'gp_informed') {
+                $normalised_answer = strtolower(trim($answer_text));
+
+                if ($normalised_answer === 'yes') {
+                    $email_answer = '';
+
+                    foreach (['email_address', 'GP_email_address'] as $email_slug) {
+                        if (!isset($answers_by_slug[$email_slug])) {
+                            continue;
+                        }
+
+                        $email_entry = $answers_by_slug[$email_slug];
+                        $email_answer = trim((string) $email_entry->answer_text());
+
+                        if ($email_answer === '') {
+                            $entry_details = $email_entry->to_array();
+                            if (is_array($entry_details) && isset($entry_details['answer'])) {
+                                $email_answer = trim((string) $entry_details['answer']);
+                            }
+                        }
+
+                        if ($email_answer !== '') {
+                            break;
+                        }
+                    }
+
+                    if ($email_answer !== '') {
+                        $output .= '<br><small>GP email: '.PerchUtil::html($email_answer).'</small>';
+                    }
+                }
+            }
+
+            echo '<td>'.$output.'</td>';
             echo '</tr>';
         }
 


### PR DESCRIPTION
## Summary
- remove the GP email append from the member edit questionnaire view
- display the GP email beneath the GP informed answer in the order questions tab when the response is yes

## Testing
- php -l perch/addons/apps/perch_members/modes/members.edit.post.php
- php -l perch/addons/apps/perch_shop_orders/modes/order.questions.post.php

------
https://chatgpt.com/codex/tasks/task_b_68dd3d4616d88324b6125d64290104bd