### PR TITLE
Read pharmacy order updates from the database

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
@@ -157,18 +157,371 @@ class PerchShop_Order extends PerchShop_Base
 
 
 		}
-	public function getOrderPharmacyDetails( $orderNumber){
-	   $pharmacy_api = new PerchShop_PharmacyOrderApiClient('https://api.myprivatechemist.com/api', '4a1f7a59-9d24-4e38-a3ff-9f8be74c916b');
-   $response =[];
-         $response = $pharmacy_api->getOrderDetails($orderNumber);
-              //   echo "response";
-         	//print_r($response);
-         if($response["success"]){
-         return $response["data"];
-           }
-	}
+        public function getOrderPharmacyDetails($orderNumber)
+        {
+                $orderNumber = trim((string)$orderNumber);
 
-	public function isReorder($Customer){
+                if ($orderNumber === '') {
+                        return [];
+                }
+
+                $details = $this->getPharmacyDetailsFromDatabase($orderNumber);
+
+                if ($details !== null) {
+                        return $details;
+                }
+
+                $pharmacy_api = new PerchShop_PharmacyOrderApiClient('https://api.myprivatechemist.com/api', '4a1f7a59-9d24-4e38-a3ff-9f8be74c916b');
+                $response = $pharmacy_api->getOrderDetails($orderNumber);
+
+                if (isset($response['success']) && $response['success']) {
+                        return $response['data'];
+                }
+
+                return [];
+        }
+
+        private function getPharmacyDetailsFromDatabase($orderNumber)
+        {
+                $db = $this->db;
+
+                try {
+                        $table_sql = 'SELECT DISTINCT TABLE_NAME FROM information_schema.COLUMNS '
+                                .'WHERE TABLE_SCHEMA = DATABASE() AND COLUMN_NAME='.$db->pdb('pharmacy_orderID');
+                        $tables = $db->get_rows_flat($table_sql);
+                } catch (Exception $e) {
+                        return null;
+                }
+
+                if (!PerchUtil::count($tables)) {
+                        return null;
+                }
+
+                $tables = array_values(array_filter($tables, function ($table) {
+                        return strpos($table, PERCH_DB_PREFIX) === 0;
+                }));
+
+                if (!PerchUtil::count($tables)) {
+                        return null;
+                }
+
+                try {
+                        $table_list = $db->implode_for_sql_in($tables);
+                        $column_sql = 'SELECT TABLE_NAME, COLUMN_NAME FROM information_schema.COLUMNS '
+                                .'WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('.$table_list.')';
+                        $columns = $db->get_rows($column_sql);
+                } catch (Exception $e) {
+                        return null;
+                }
+
+                if (!PerchUtil::count($columns)) {
+                        return null;
+                }
+
+                $meta = [];
+
+                foreach ($columns as $column) {
+                        $table = $column['TABLE_NAME'];
+                        $name  = $column['COLUMN_NAME'];
+
+                        if (!isset($meta[$table])) {
+                                $meta[$table] = [
+                                        'column_map'        => [],
+                                        'has_detail_column' => false,
+                                        'order_column'      => null,
+                                ];
+                        }
+
+                        $lower = strtolower($name);
+                        $meta[$table]['column_map'][$lower] = $name;
+                }
+
+                $detail_candidates = [
+                        'status',
+                        'pharmacy_status',
+                        'order_status',
+                        'status_text',
+                        'dispatchdate',
+                        'dispatch_date',
+                        'dispatched_at',
+                        'dispatcheddate',
+                        'trackingno',
+                        'tracking_no',
+                        'trackingnumber',
+                        'tracking_number',
+                        'trackingref',
+                        'tracking_reference',
+                ];
+
+                $order_candidates = ['updated_at', 'modified_at', 'created_at', 'created', 'id'];
+
+                foreach ($meta as $table => &$info) {
+                        foreach ($detail_candidates as $candidate) {
+                                if (isset($info['column_map'][$candidate])) {
+                                        $info['has_detail_column'] = true;
+                                        break;
+                                }
+                        }
+
+                        foreach ($order_candidates as $candidate) {
+                                if (isset($info['column_map'][$candidate])) {
+                                        $info['order_column'] = $info['column_map'][$candidate];
+                                        break;
+                                }
+                        }
+                }
+                unset($info);
+
+                $ordered_tables = array_keys($meta);
+                usort($ordered_tables, function ($a, $b) use ($meta) {
+                        $a_has = $meta[$a]['has_detail_column'];
+                        $b_has = $meta[$b]['has_detail_column'];
+
+                        if ($a_has === $b_has) {
+                                return 0;
+                        }
+
+                        return $a_has ? -1 : 1;
+                });
+
+                foreach ($ordered_tables as $table) {
+                        $order_sql = '';
+
+                        if (!empty($meta[$table]['order_column'])) {
+                                $order_sql = ' ORDER BY `'.$meta[$table]['order_column'].'` DESC';
+                        }
+
+                        $sql = 'SELECT * FROM '.$table
+                                .' WHERE pharmacy_orderID='.$db->pdb($orderNumber)
+                                .$order_sql
+                                .' LIMIT 1';
+
+                        $row = $db->get_row($sql);
+
+                        if (!PerchUtil::count($row)) {
+                                continue;
+                        }
+
+                        $details = $this->normalizePharmacyDetailsFromRow($row);
+
+                        if ($this->hasPharmacyDetails($details)) {
+                                return $details;
+                        }
+                }
+
+                return null;
+        }
+
+        private function normalizePharmacyDetailsFromRow(array $row)
+        {
+                $lower_row = array_change_key_case($row, CASE_LOWER);
+
+                $status = $this->findFirstValueForKeys($lower_row, ['status', 'pharmacy_status', 'order_status', 'status_text']);
+                $dispatch_date = $this->findFirstValueForKeys($lower_row, ['dispatchdate', 'dispatch_date', 'dispatched_at', 'dispatcheddate']);
+                $tracking_no = $this->findFirstValueForKeys($lower_row, ['trackingno', 'tracking_no', 'trackingnumber', 'tracking_number', 'trackingref', 'tracking_reference']);
+
+                $payload = $this->extractPharmacyPayload($lower_row);
+
+                if (is_array($payload)) {
+                        $payload_lower = array_change_key_case($payload, CASE_LOWER);
+
+                        if ($status === null) {
+                                $status = $this->findFirstValueForKeys($payload_lower, ['status', 'orderstatus', 'status_text']);
+                        }
+
+                        if ($dispatch_date === null) {
+                                $dispatch_date = $this->findFirstValueForKeys($payload_lower, ['dispatchdate', 'dispatch_date', 'dispatcheddate']);
+                        }
+
+                        if ($tracking_no === null) {
+                                $tracking_no = $this->findFirstValueForKeys($payload_lower, ['trackingno', 'tracking_no', 'trackingnumber', 'tracking_number', 'trackingref', 'tracking_reference']);
+                        }
+                }
+
+                if ($status === null || $dispatch_date === null || $tracking_no === null) {
+                        $message_sources = ['pharmacy_message', 'message', 'notes'];
+
+                        foreach ($message_sources as $source) {
+                                if (!isset($lower_row[$source]) || !is_string($lower_row[$source])) {
+                                        continue;
+                                }
+
+                                $parsed = $this->parsePharmacyMessageString($lower_row[$source]);
+
+                                if ($status === null && isset($parsed['status'])) {
+                                        $status = $parsed['status'];
+                                }
+
+                                if ($dispatch_date === null && isset($parsed['dispatchDate'])) {
+                                        $dispatch_date = $parsed['dispatchDate'];
+                                }
+
+                                if ($tracking_no === null && isset($parsed['trackingNo'])) {
+                                        $tracking_no = $parsed['trackingNo'];
+                                }
+
+                                if ($status !== null && $dispatch_date !== null && $tracking_no !== null) {
+                                        break;
+                                }
+                        }
+                }
+
+                $details = [
+                        'status'       => $status,
+                        'dispatchDate' => $dispatch_date,
+                        'trackingNo'   => $tracking_no,
+                ];
+
+                if (is_array($payload) && PerchUtil::count($payload)) {
+                        $details['payload'] = $payload;
+                }
+
+                return $details;
+        }
+
+        private function extractPharmacyPayload(array $row)
+        {
+                $candidates = ['payload', 'pharmacy_payload', 'response_payload', 'data', 'pharmacy_data', 'pharmacy_message', 'message'];
+
+                foreach ($candidates as $candidate) {
+                        if (!array_key_exists($candidate, $row)) {
+                                continue;
+                        }
+
+                        $value = $row[$candidate];
+
+                        if (is_array($value)) {
+                                return $value;
+                        }
+
+                        if (!is_string($value)) {
+                                continue;
+                        }
+
+                        $trimmed = trim($value);
+
+                        if ($trimmed === '') {
+                                continue;
+                        }
+
+                        $decoded = json_decode($trimmed, true);
+
+                        if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                                return $decoded;
+                        }
+
+                        $unserialized = @unserialize($trimmed);
+
+                        if ($unserialized !== false && is_array($unserialized)) {
+                                return $unserialized;
+                        }
+                }
+
+                return null;
+        }
+
+        private function parsePharmacyMessageString($message)
+        {
+                if (!is_string($message)) {
+                        return [];
+                }
+
+                $text = trim($message);
+
+                if ($text === '') {
+                        return [];
+                }
+
+                $details = [];
+
+                $patterns = [
+                        'status'       => '/status\s*[:=-]\s*([^;\r\n]+)/i',
+                        'dispatchDate' => '/dispatch(?:ed)?\s*date\s*[:=-]\s*([^;\r\n]+)/i',
+                        'trackingNo'   => '/tracking(?:\s*(?:no|number|#))?\s*[:=-]\s*([^;\r\n]+)/i',
+                ];
+
+                foreach ($patterns as $key => $pattern) {
+                        if (preg_match($pattern, $text, $match)) {
+                                $details[$key] = trim($match[1]);
+                        }
+                }
+
+                if (isset($details['status']) && isset($details['dispatchDate']) && isset($details['trackingNo'])) {
+                        return $details;
+                }
+
+                $segments = preg_split('/[;\r\n]+/', $text);
+
+                foreach ($segments as $segment) {
+                        if (strpos($segment, ':') !== false) {
+                                list($key, $value) = array_map('trim', explode(':', $segment, 2));
+                        } elseif (strpos($segment, '=') !== false) {
+                                list($key, $value) = array_map('trim', explode('=', $segment, 2));
+                        } else {
+                                continue;
+                        }
+
+                        $normalized = strtolower(str_replace([' ', '-', '_'], '', $key));
+
+                        switch ($normalized) {
+                                case 'status':
+                                case 'orderstatus':
+                                        if (!isset($details['status'])) {
+                                                $details['status'] = $value;
+                                        }
+                                        break;
+                                case 'dispatchdate':
+                                case 'dispatcheddate':
+                                case 'dispatch':
+                                        if (!isset($details['dispatchDate'])) {
+                                                $details['dispatchDate'] = $value;
+                                        }
+                                        break;
+                                case 'trackingno':
+                                case 'trackingnumber':
+                                case 'tracking':
+                                case 'trackingref':
+                                        if (!isset($details['trackingNo'])) {
+                                                $details['trackingNo'] = $value;
+                                        }
+                                        break;
+                        }
+                }
+
+                return $details;
+        }
+
+        private function findFirstValueForKeys(array $data, array $keys)
+        {
+                foreach ($keys as $key) {
+                        if (!array_key_exists($key, $data)) {
+                                continue;
+                        }
+
+                        $value = $data[$key];
+
+                        if ($value === null || $value === '') {
+                                continue;
+                        }
+
+                        return is_string($value) ? trim($value) : $value;
+                }
+
+                return null;
+        }
+
+        private function hasPharmacyDetails(array $details)
+        {
+                foreach (['status', 'dispatchDate', 'trackingNo'] as $key) {
+                        if (isset($details[$key]) && $details[$key] !== '' && $details[$key] !== null) {
+                                return true;
+                        }
+                }
+
+                return false;
+        }
+
+        public function isReorder($Customer){
 		$Orders = new PerchShop_Orders($this->api);
         //	$Customer = $Customers->find_from_logged_in_member();
             $orders = $Orders->findAll_for_customer($Customer);


### PR DESCRIPTION
## Summary
- look up pharmacy order updates from database tables before performing an API call
- normalise stored payloads and messages to expose status, dispatch date, and tracking number
- keep the external API request as a fallback when no database data exists

## Testing
- php -l perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php

------
https://chatgpt.com/codex/tasks/task_b_68dfca1f6d5c8324bfef4e4ad14f164f