### PR TITLE
Persist pharmacy detail updates in database

### DIFF
--- a/sql/p4_orders_match_pharmacy_alter.sql
+++ b/sql/p4_orders_match_pharmacy_alter.sql
@@ -1,0 +1,33 @@
+-- SQL statements to ensure pharmacy order tracking columns exist on p4_orders_match_pharmacy.
+-- Run each statement individually if your MySQL version does not support `ADD COLUMN IF NOT EXISTS`.
+
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `status` VARCHAR(255) NULL DEFAULT NULL;
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `pharmacy_status` VARCHAR(255) NULL DEFAULT NULL;
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `order_status` VARCHAR(255) NULL DEFAULT NULL;
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `status_text` VARCHAR(255) NULL DEFAULT NULL;
+
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `dispatchdate` DATETIME NULL DEFAULT NULL;
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `dispatch_date` DATETIME NULL DEFAULT NULL;
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `dispatched_at` DATETIME NULL DEFAULT NULL;
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `dispatcheddate` DATETIME NULL DEFAULT NULL;
+
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `trackingno` VARCHAR(255) NULL DEFAULT NULL;
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `tracking_no` VARCHAR(255) NULL DEFAULT NULL;
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `trackingnumber` VARCHAR(255) NULL DEFAULT NULL;
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `tracking_number` VARCHAR(255) NULL DEFAULT NULL;
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `trackingref` VARCHAR(255) NULL DEFAULT NULL;
+ALTER TABLE `p4_orders_match_pharmacy`
+    ADD COLUMN IF NOT EXISTS `tracking_reference` VARCHAR(255) NULL DEFAULT NULL;


### PR DESCRIPTION
## Summary
- update the pharmacy lookup to write normalized status, dispatch, and tracking values back to p4_orders_match_pharmacy when they change
- add helpers to locate candidate columns and compare values safely before issuing the update

## Testing
- php -l perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php

------
https://chatgpt.com/codex/tasks/task_b_68dfca1f6d5c8324bfef4e4ad14f164f