### PR TITLE
Handle missing affiliate member when generating invoice

### DIFF
--- a/perch/addons/apps/perch_members/affiliates/payouts/generate_invoice/index.php
+++ b/perch/addons/apps/perch_members/affiliates/payouts/generate_invoice/index.php
@@ -67,11 +67,29 @@ function generateInvoiceHTML($data) {
         $Affiliate = new PerchMembers_Affiliate($API);
         $Members = new PerchMembers_Members($API);
   $payout_details=$Affiliate->getAffiliatePayoutDetails($_GET['payout_id']);
-  $affdetails=$Affiliate->getAffiliateDetails($payout_details['affiliate_id']);
-  $Member = $Members->find($affdetails["member_id"]);
-     $details = $Member->to_array();
+  if (!$payout_details) {
+      PerchUtil::redirect('../../../../../../core/apps/content/index.php');
+  }
 
- $activity= json_decode($payout_details["referral_snapshot"]);
+  $affdetails=$Affiliate->getAffiliateDetails($payout_details['affiliate_id']);
+  if (!$affdetails) {
+      PerchUtil::redirect('../../../../../../core/apps/content/index.php');
+  }
+
+  $Member = $Members->find($affdetails["member_id"]);
+  $details = [
+      'first_name' => '',
+      'last_name' => '',
+      'email' => '',
+  ];
+  if ($Member instanceof PerchMembers_Member) {
+      $details = $Member->to_array();
+  }
+
+ $activity= json_decode($payout_details["referral_snapshot"], true);
+ if (!is_array($activity)) {
+     $activity = [];
+ }
 // Sample data
 $data = [
     'invoice_date' => date("d/M/Y"),


### PR DESCRIPTION
## Summary
- guard against missing payout and affiliate records before generating invoices
- ensure member details exist before calling to_array to avoid fatal errors
- default referral activity to an empty array when JSON decoding fails

## Testing
- php -l perch/addons/apps/perch_members/affiliates/payouts/generate_invoice/index.php

------
https://chatgpt.com/codex/tasks/task_b_68e4da578d948324b4006297e99d7616