### PR TITLE
Filter pharmacy assessment questions by questionnaire type

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
@@ -232,6 +232,11 @@ class PerchShop_Order extends PerchShop_Base
         	}
         }
 
+                $Questionnaires = new PerchMembers_Questionnaires($this->api);
+                $questionnaire_type_key = ($questionnaire_type === 're-order') ? 're-order' : 'first-order';
+                $allowed_questions = array_keys($Questionnaires->get_questions_answers($questionnaire_type_key));
+                $allowed_questions = array_flip($allowed_questions);
+
 
                 $questionnaireID = null;
                 $dynamicFields  = PerchUtil::json_safe_decode($this->orderDynamicFields(), true);
@@ -279,6 +284,12 @@ class PerchShop_Order extends PerchShop_Base
 
                 if (PerchUtil::count($questionnaire)) {
                     foreach ($questionnaire as $questiondet) {
+                        $question_slug = $questiondet['question_slug'] ?? null;
+
+                        if ($question_slug === null || !isset($allowed_questions[$question_slug])) {
+                            continue;
+                        }
+
                         if (isset($questiondet["question_text"]) && isset($questiondet["answer_text"])) {
                             if ($questiondet["question_text"] != "" && $questiondet["answer_text"] != "") {
                                 $questions_items[] = [


### PR DESCRIPTION
## Summary
- load the questionnaire configuration for the order type
- restrict pharmacy assessment payload to known questions for first orders and re-orders

## Testing
- php -l perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php

------
https://chatgpt.com/codex/tasks/task_b_68e52f53a7548324b8efb48ffadb093b