### PR TITLE
Add 'Add new appointment' CTA to My Appointments page

### DIFF
--- a/perch/templates/pages/client/my-appointments.php
+++ b/perch/templates/pages/client/my-appointments.php
@@ -41,6 +41,7 @@ perch_layout('client/header', [
     <div class="client-hero">
       <h1>My appointments</h1>
       <p>View your booked nutrition and wellbeing appointments in one place.</p>
+      <a href="/client/appointments" class="btn btn-primary client-hero__cta">Add new appointment</a>
     </div>
 
     <?php if (!empty($appointments)): ?>
@@ -94,6 +95,7 @@ perch_layout('client/header', [
 
 <style>
   .appointments-list { display:grid; gap:16px; }
+  .client-hero__cta { margin-top:12px; }
   .appointment-item { background:#fff; border:1px solid #e5e7eb; border-radius:14px; padding:16px; box-shadow:0 10px 22px rgba(15,23,42,.05); }
   .appointment-item__header { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; margin-bottom:12px; }
   .appointment-item__header h2 { margin:0; font-size:1.15rem; }


### PR DESCRIPTION
### Motivation
- Provide a clear primary action so users can start booking a new appointment directly from the My Appointments hero section.

### Description
- Added a primary CTA link to `perch/templates/pages/client/my-appointments.php`: `<a href="/client/appointments" class="btn btn-primary client-hero__cta">Add new appointment</a>` and added `.client-hero__cta { margin-top:12px; }` to the inline styles; the existing empty-state booking button is left intact.

### Testing
- Ran `php -l perch/templates/pages/client/my-appointments.php` and it returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d7be9ecce08324b5c04c9d0fbfac58)