### PR TITLE
Add appointment status badge and associated order link to My Appointments

### DIFF
--- a/perch/templates/pages/client/my-appointments.php
+++ b/perch/templates/pages/client/my-appointments.php
@@ -20,7 +20,7 @@ $DB = $API->get('DB');
 $table = PERCH_DB_PREFIX . 'appointments';
 
 if ($memberID) {
-    $sql = 'SELECT appointmentID, productName, productPrice, appointmentDate, appointmentDateLabel, slotLabel, goal, medical, notes, createdAt '
+    $sql = 'SELECT appointmentID, productName, productPrice, appointmentDate, appointmentDateLabel, slotLabel, goal, medical, notes, orderID, appointmentStatus, createdAt '
         . 'FROM ' . $table . ' '
         . 'WHERE memberID=' . $DB->pdb((int) $memberID) . ' '
         . 'ORDER BY appointmentDate DESC, appointmentID DESC';
@@ -54,6 +54,12 @@ perch_layout('client/header', [
             </header>
             <dl class="appointment-item__meta">
               <div>
+                <dt>Status</dt>
+                <dd>
+                  <span class="appointment-item__status appointment-item__status--<?php echo htmlspecialchars((string) ($appointment['appointmentStatus'] ?? 'pending'), ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars(ucfirst((string) ($appointment['appointmentStatus'] ?? 'pending')), ENT_QUOTES, 'UTF-8'); ?></span>
+                </dd>
+              </div>
+              <div>
                 <dt>Date</dt>
                 <dd><?php echo htmlspecialchars($appointment['appointmentDateLabel'] ?? ($appointment['appointmentDate'] ?? '—'), ENT_QUOTES, 'UTF-8'); ?></dd>
               </div>
@@ -66,6 +72,13 @@ perch_layout('client/header', [
                 <dd><?php echo htmlspecialchars(date('d M Y, H:i', strtotime((string) ($appointment['createdAt'] ?? 'now'))), ENT_QUOTES, 'UTF-8'); ?></dd>
               </div>
             </dl>
+
+            <?php if (!empty($appointment['orderID'])): ?>
+              <div class="appointment-item__section">
+                <h3>Associated order</h3>
+                <p><a href="/client/order?id=<?php echo urlencode((string) $appointment['orderID']); ?>">View order #<?php echo htmlspecialchars((string) $appointment['orderID'], ENT_QUOTES, 'UTF-8'); ?></a></p>
+              </div>
+            <?php endif; ?>
 
             <?php if (!empty($appointment['goal'])): ?>
               <div class="appointment-item__section">
@@ -106,6 +119,12 @@ perch_layout('client/header', [
   .appointment-item__section { border-top:1px solid #e5e7eb; padding-top:10px; margin-top:10px; }
   .appointment-item__section h3 { margin:0 0 6px; font-size:.95rem; }
   .appointment-item__section p { margin:0; color:#334155; }
+  .appointment-item__section a { font-weight:600; text-decoration:none; }
+  .appointment-item__section a:hover { text-decoration:underline; }
+  .appointment-item__status { display:inline-block; border-radius:999px; padding:4px 10px; font-size:.82rem; font-weight:700; text-transform:capitalize; }
+  .appointment-item__status--pending { background:#fef9c3; color:#854d0e; }
+  .appointment-item__status--confirmed { background:#dcfce7; color:#166534; }
+  .appointment-item__status--completed { background:#dbeafe; color:#1e3a8a; }
   .empty-state { text-align:center; border:1px dashed #cbd5e1; border-radius:14px; padding:28px 20px; background:#fff; }
   .empty-state h2 { margin-bottom:8px; }
   .empty-state p { margin:0 0 14px; color:#64748b; }


### PR DESCRIPTION
### Motivation
- Surface appointment state and related order information on the client "My appointments" page so users can see status and navigate to linked orders. 
- Improve clarity of each appointment card by showing a prominent, styled status label. 

### Description
- Update the query in `perch/templates/pages/client/my-appointments.php` to include `orderID` and `appointmentStatus` in the selected fields. 
- Render a status row in the appointment meta with a status badge using `appointmentStatus` (shows `pending`, `confirmed`, or `completed`). 
- Add an "Associated order" section that displays when `orderID` is present and links to `/client/order?id=<orderID>`. 
- Add small CSS rules to style the status badges and the associated-order link. 

### Testing
- Ran PHP lint on the modified file with `php -l perch/templates/pages/client/my-appointments.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dce90ab398832490e7301bc99adbe2)