### PR TITLE
Avoid using fixed Stripe price IDs when promo code applied (preserve discounted totals)

### DIFF
--- a/perch/addons/apps/perch_shop/lib/gateways/PerchShopGateway_default.class.php
+++ b/perch/addons/apps/perch_shop/lib/gateways/PerchShopGateway_default.class.php
@@ -89,7 +89,7 @@ public function take_klarna_payment($Order, $opts)
     }
 }
 
-	private function get_order_checkout_line_items($Order, $currency, $default_price_id='', $default_product_id='', $test_mode=false)
+	private function get_order_checkout_line_items($Order, $currency, $default_price_id='', $default_product_id='', $test_mode=false, $allow_price_ids=true)
 	{
 		$OrderItems = new PerchShop_OrderItems($this->api);
 		$items = $OrderItems->get_by('orderID', $Order->id());
@@ -161,7 +161,7 @@ public function take_klarna_payment($Order, $opts)
 				'quantity' => $qty,
 			];
 
-			if ($stripe_price_id !== '') {
+			if ($allow_price_ids && $stripe_price_id !== '') {
 				$line_item['price'] = $stripe_price_id;
 			} else {
 				$line_item['currency'] = $currency;
@@ -255,7 +255,17 @@ public function take_payment($Order, $opts)
         }
     }
 
-    $order_line_items = $this->get_order_checkout_line_items($Order, $currency, $stripe_price_id, $stripe_product_id, $is_test_mode);
+    $has_discount_code = ($promotion_code !== '');
+    $allow_price_ids = !$has_discount_code;
+
+    $order_line_items = $this->get_order_checkout_line_items(
+        $Order,
+        $currency,
+        $stripe_price_id,
+        $stripe_product_id,
+        $is_test_mode,
+        $allow_price_ids
+    );
 
     if (!PerchUtil::count($order_line_items)) {
         $amount = (int) round($orderTotal * 100);
@@ -286,8 +296,6 @@ public function take_payment($Order, $opts)
     }
 
     curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($checkout_fields));
-
-print_r($checkout_fields);
     $response = curl_exec($ch);
 //echo "take payment";print_r($response);
     curl_close($ch);


### PR DESCRIPTION
### Motivation
- Prevent customers being redirected to Stripe Checkout showing full product prices when an order contains a promotional/discount code that reduces the order total.

### Description
- Add an `$allow_price_ids` parameter to `get_order_checkout_line_items` and only use fixed Stripe `price` IDs when `allow_price_ids` is true.
- When a promotion/discount code is present (`$promotion_code = $Order->get_discount_code()`), force line items to be sent as dynamic `price_data` (unit amounts) so Stripe receives the discounted amounts.
- Preserve existing Stripe promotion-code lookup and include the resolved Stripe promotion code in `discounts[0][promotion_code]` when found.
- Remove leftover debug output (`print_r($checkout_fields)`) from the Stripe checkout session creation path.

### Testing
- Ran PHP syntax check with `php -l perch/addons/apps/perch_shop/lib/gateways/PerchShopGateway_default.class.php` which reported no syntax errors.
- Verified the modified file is the only runtime change by inspecting the updated gateway implementation and confirming the `get_order_checkout_line_items` call now receives the `allow_price_ids` flag.
- Confirmed the `print_r` debug output was removed from the checkout session flow by inspecting the updated code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e5e6fff9288324848cb119d1dd5d61)