### PR TITLE
Fix variant tax group handling when inheriting parent price

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Product.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Product.class.php
@@ -402,10 +402,12 @@ class PerchShop_Product extends PerchShop_Base
 
         $prices = $this->get($price_field);
 
-        // Variant with no different price? Return the parent.
+        // Variant with no different price? Use parent pricing data but keep variant tax rules.
         if (!$prices && $this->is_variant()) {
             $Parent = $this->get_parent();
-            return $Parent->get_prices($qty, $pricing, $price_tax_mode, $CustomerTaxLocation, $HomeTaxLocation, $Currency, $Totaliser);
+            if ($Parent) {
+                $prices = $Parent->get($price_field);
+            }
         }
 
         if ($prices) {


### PR DESCRIPTION
### Motivation
- Preserve a variant's assigned `tax_group` when it has no explicit price so tax calculations on cart and checkout use the variant's tax rules rather than the parent’s.

### Description
- Update `PerchShop_Product::get_prices()` to, for variants with no price, load the parent price via `Parent->get($price_field)` instead of returning `Parent->get_prices(...)`, keeping `$this` as the tax subject (file: `perch/addons/apps/perch_shop/lib/PerchShop_Product.class.php`).

### Testing
- Ran a syntax check with `php -l perch/addons/apps/perch_shop/lib/PerchShop_Product.class.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8b3eba8ec8324a4a755c8ea162b99)