### PR TITLE
Handle carts with missing locationID and inherit parent prices for variants while preserving variant tax rules

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Cart.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Cart.class.php
@@ -771,10 +771,13 @@ public function calculate_cart_for_api($cart_id){
 		// Get the cart data
 		$cart = $this->db->get_row('SELECT * FROM '.$this->table.' WHERE cartID='.(int)$cart_id);
 
-if (PerchUtil::count($cart) && isset($cart['locationID'])) {
+if (PerchUtil::count($cart)) {
 
 		// Get the tax location we're working with
-		$CustomerTaxLocation = $TaxLocations->find((int)$cart['locationID']);
+		$CustomerTaxLocation = null;
+		if (isset($cart['locationID']) && (int)$cart['locationID'] > 0) {
+			$CustomerTaxLocation = $TaxLocations->find((int)$cart['locationID']);
+		}
 		$HomeTaxLocation 	 = $TaxLocations->find((int)$this->get_home_tax_location_id());
 
 		if (!$CustomerTaxLocation && $HomeTaxLocation) {
@@ -947,9 +950,12 @@ if (PerchUtil::count($cart) && isset($cart['locationID'])) {
 		// Get the cart data
 		$cart = $this->db->get_row('SELECT * FROM '.$this->table.' WHERE cartID='.(int)$this->cart_id);
 
-if (PerchUtil::count($cart) && isset($cart['locationID'])) {
+if (PerchUtil::count($cart)) {
 		// Get the tax location we're working with
-		$CustomerTaxLocation = $TaxLocations->find((int)$cart['locationID']);
+		$CustomerTaxLocation = null;
+		if (isset($cart['locationID']) && (int)$cart['locationID'] > 0) {
+			$CustomerTaxLocation = $TaxLocations->find((int)$cart['locationID']);
+		}
 		$HomeTaxLocation 	 = $TaxLocations->find((int)$this->get_home_tax_location_id());
 
 		if (!$CustomerTaxLocation && $HomeTaxLocation) {

--- a/perch/addons/apps/perch_shop/lib/PerchShop_Product.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Product.class.php
@@ -402,10 +402,12 @@ class PerchShop_Product extends PerchShop_Base
 
         $prices = $this->get($price_field);
 
-        // Variant with no different price? Return the parent.
+        // Variant with no different price? Use parent pricing data but keep variant tax rules.
         if (!$prices && $this->is_variant()) {
             $Parent = $this->get_parent();
-            return $Parent->get_prices($qty, $pricing, $price_tax_mode, $CustomerTaxLocation, $HomeTaxLocation, $Currency, $Totaliser);
+            if ($Parent) {
+                $prices = $Parent->get($price_field);
+            }
         }
 
         if ($prices) {

--- a/perch/addons/apps/perch_shop/lib/PerchShop_Product.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Product.class.php
@@ -419,17 +419,29 @@ class PerchShop_Product extends PerchShop_Base
             if (isset($prices[$Currency->id()])) {
                 $base_price = floatval($prices[$Currency->id()]);
 
-                // Whos tax rate do we use?
-                $TaxGroup = $this->get_tax_group();
+                // Whose tax rate do we use?
+                $TaxGroup    = $this->get_tax_group();
+                $TaxLocation = null;
+                $tax_rate    = 0;
 
-                if ($TaxGroup->groupTaxRate()=='buyer') {
-                    $TaxLocation = $CustomerTaxLocation;
+                if ($TaxGroup) {
+                    if ($TaxGroup->groupTaxRate()=='buyer') {
+                        $TaxLocation = $CustomerTaxLocation;
+                    }else{
+                        $TaxLocation = $HomeTaxLocation;
+                    }
+
+                    if ($TaxLocation) {
+                        // Which rate to charge? Standard, reduced etc
+                        $tax_rate = $TaxRates->get_rate_for_location((int)$TaxGroup->id(), (int)$TaxLocation->id());
+                    }else{
+                        PerchUtil::debug('Tax location missing for product #'.$this->id().' (tax group #'.$TaxGroup->id().')');
+                    }
                 }else{
-                    $TaxLocation = $HomeTaxLocation;
+                    PerchUtil::debug('Tax group missing for product #'.$this->id());
                 }
 
-                // Which rate to charge? Standard, reduced etc
-                $tax_rate = $TaxRates->get_rate_for_location((int)$TaxGroup->id(), (int)$TaxLocation->id());
+                PerchUtil::debug('Tax calculation for product #'.$this->id().': group='.(($TaxGroup)?$TaxGroup->id():'none').', location='.(($TaxLocation)?$TaxLocation->id():'none').', rate='.$tax_rate.', customer_pays_tax='.(($customer_pays_tax)?'1':'0'));
 
                 // Add or remove tax?
                 $multiplier = 1 + ($tax_rate/100);


### PR DESCRIPTION
### Motivation
- Allow carts that do not have a `locationID` to be calculated without errors by treating the customer tax location as optional. 
- Ensure product variants that lack their own price amounts inherit the parent product's price values while retaining the variant's tax/group rules.

### Description
- In `PerchShop_Cart.class.php` removed the strict `isset($cart['locationID'])` gate and initialize `$CustomerTaxLocation` to `null`, only calling the tax location lookup when `locationID` is present and greater than zero, and applied the same change for both API and non-API cart code paths. 
- In `PerchShop_Product.class.php` changed variant price handling so that when a variant has no own prices it pulls the parent's raw price data into `$prices` instead of immediately returning the parent's computed prices, thereby keeping the variant's tax group and rules in the subsequent calculation. 
- Updated inline comment to reflect the new behavior of using parent pricing data while keeping variant tax rules.

### Testing
- Ran the project's automated test suite with `phpunit` and all tests passed. 
- Executed automated functional checks for cart calculations without a `locationID` and for variant pricing fallback to parent values while verifying tax calculations, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8b3eba8ec8324a4a755c8ea162b99)