### PR TITLE
Add new comms create-order payload fields

### DIFF
--- a/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
+++ b/perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php
@@ -462,9 +462,34 @@ echo "questions_items";
              $shippingCountry = $ShippingAddr->get_country_name() ?? '';
          }
 
+         $originOrderId = (string)$this->id();
+         $stripePaymentId = '';
+         $gatewayReference = trim((string)$this->orderGatewayRef());
+         if ($gatewayReference !== '' && strtolower((string)$this->orderGateway()) === 'stripe') {
+             $stripePaymentId = $gatewayReference;
+         }
+
+         $subtotal = (float)$this->orderSubtotal();
+         $deliveryCost = (float)$this->orderShippingTotal();
+         $total = (float)$this->orderTotal();
+
+         $courierService = '';
+         if (is_array($dynamicFields)) {
+             $candidateCourierService = strtoupper(trim((string)($dynamicFields['courierService'] ?? $dynamicFields['courier_service'] ?? '')));
+             if (in_array($candidateCourierService, ['SEB', 'TPN24'], true)) {
+                 $courierService = $candidateCourierService;
+             }
+         }
+
          $orderData = [
              "status" => "PAYMENT_RECEIVED",
              "customerId" => $Customer->pharmacy_refid(),
+             "originOrderId" => $originOrderId,
+             "stripePaymentId" => $stripePaymentId,
+             "subtotal" => $subtotal,
+             "deliveryCost" => $deliveryCost,
+             "total" => $total,
+             "courierService" => $courierService,
              "items" => $order_items,
              "shipping" => [
                  "addressLine1" => $shippingAddressLine1,


### PR DESCRIPTION
### Motivation
- The comms-service create-order payload needs additional optional fields so external systems can link orders, payments and courier preferences for dispatch.

### Description
- Updated `PerchShop_Order::sendOrdertoPharmacy()` in `perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php` to include new optional payload fields: `originOrderId`, `stripePaymentId`, `subtotal`, `deliveryCost`, `total`, and `courierService`.
- `originOrderId` is populated from the local order ID and `stripePaymentId` is set from `orderGatewayRef` only when the order gateway is Stripe.
- `subtotal`, `deliveryCost`, and `total` are sent as numeric values derived from `orderSubtotal()`, `orderShippingTotal()` and `orderTotal()` respectively, and `courierService` is normalized to uppercase and restricted to allowed values (`SEB`, `TPN24`).
- All new fields are optional-safe and default to empty string or numeric zero when not present.

### Testing
- Ran PHP syntax check with `php -l perch/addons/apps/perch_shop/lib/PerchShop_Order.class.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e9d37817d883249578d92ad522097d)